### PR TITLE
Fix BasicResponse interface

### DIFF
--- a/ts-sdk/src/index.ts
+++ b/ts-sdk/src/index.ts
@@ -5,7 +5,6 @@ const DEFAULT_BASE_URL = "http://127.0.0.1:9375";
 // General Responses
 export interface BasicResponse {
   message: string;
-  title: string;
 }
 
 export interface BooleanResponse {


### PR DESCRIPTION
## Summary
- fix BasicResponse definition in the TypeScript SDK

## Testing
- `npm run build` in `ts-sdk`