### PR TITLE
Add login automation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ For more details, see the [Getting Started Guide](https://docs.screenpi.pe/termi
 ## Explore Further
 
 -   **Vercel AI SDK Example:** Learn how to use Terminator with AI in the [PDF-to-Form example](https://github.com/mediar-ai/terminator/tree/main/examples/pdf-to-form).
+-   **Login Automator Example:** A minimal [dummy login automation](https://github.com/mediar-ai/terminator/tree/main/examples/login-automator) using the Python SDK.
 -   **MCP:** Discover [how to Vibe Work using MCP](https://github.com/mediar-ai/terminator/tree/main/mcp).
 
 ## Technical Details & Debugging

--- a/examples/login-automator/README.md
+++ b/examples/login-automator/README.md
@@ -1,0 +1,26 @@
+# Example: Windows Login Automator
+
+This example demonstrates how to automate filling a simple login form using the Terminator Python SDK.
+
+The `dummy_login.py` script opens a minimal login window with username and password fields. The `login_automator.py` script launches this window via the Terminator server and fills in the credentials automatically.
+
+## Prerequisites
+
+1. **Terminator Server** running on your machine. See the [project README](../../README.md#quick-start) for setup instructions.
+2. **Python** installed (the scripts use `sys.executable` to run the login window).
+
+## Running the example
+
+```bash
+# From the repository root
+cd examples/login-automator
+python login_automator.py
+```
+
+The automation script will:
+1. Launch `dummy_login.py` via the Terminator server.
+2. Locate the login window titled **"Dummy Login"**.
+3. Type the `DEMO_USERNAME` and `DEMO_PASSWORD` environment variables (or default values) into the form.
+4. Click the **Login** button.
+
+Adjust selectors in `login_automator.py` if your accessibility tree differs.

--- a/examples/login-automator/dummy_login.py
+++ b/examples/login-automator/dummy_login.py
@@ -1,0 +1,27 @@
+import tkinter as tk
+from tkinter import messagebox
+
+
+def do_login():
+    messagebox.showinfo("Login", f"Welcome {username_var.get()}!")
+
+root = tk.Tk()
+root.title("Dummy Login")
+
+# Username field
+username_var = tk.StringVar()
+tk.Label(root, text="Username", name="username_label").grid(row=0, column=0, padx=5, pady=5)
+username_entry = tk.Entry(root, textvariable=username_var, name="username")
+username_entry.grid(row=0, column=1, padx=5, pady=5)
+
+# Password field
+password_var = tk.StringVar()
+tk.Label(root, text="Password", name="password_label").grid(row=1, column=0, padx=5, pady=5)
+password_entry = tk.Entry(root, textvariable=password_var, show="*", name="password")
+password_entry.grid(row=1, column=1, padx=5, pady=5)
+
+# Login button
+login_button = tk.Button(root, text="Login", command=do_login, name="login_button")
+login_button.grid(row=2, column=0, columnspan=2, pady=10)
+
+root.mainloop()

--- a/examples/login-automator/login_automator.py
+++ b/examples/login-automator/login_automator.py
@@ -1,0 +1,46 @@
+import logging
+import os
+import sys
+import time
+
+SDK_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'python-sdk'))
+if SDK_PATH not in sys.path:
+    sys.path.insert(0, SDK_PATH)
+
+from desktop_use import DesktopUseClient, ApiError, ConnectionError
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+USERNAME = os.getenv('DEMO_USERNAME', 'demo@example.com')
+PASSWORD = os.getenv('DEMO_PASSWORD', 'password123')
+
+
+def run_login_automation():
+    client = DesktopUseClient()
+    login_script = os.path.join(os.path.dirname(__file__), 'dummy_login.py')
+
+    logging.info('Launching dummy login window...')
+    client.run_command(windows_command=f'{sys.executable} "{login_script}"',
+                       unix_command=f'{sys.executable} "{login_script}"')
+
+    time.sleep(2)  # Allow window to appear
+
+    try:
+        window = client.locator('window:Dummy Login')
+
+        logging.info('Filling credentials...')
+        window.locator('name:username').type_text(USERNAME)
+        window.locator('name:password').type_text(PASSWORD)
+        window.locator('name:login_button').click()
+
+        logging.info('Automation complete!')
+    except ApiError as e:
+        logging.error(f'API error: {e}')
+    except ConnectionError:
+        logging.error('Could not connect to Terminator server.')
+    except Exception as e:
+        logging.error(f'Unexpected error: {e}')
+
+
+if __name__ == '__main__':
+    run_login_automation()


### PR DESCRIPTION
/claim #24

## Summary
- add simple Tkinter login window example
- add login automation script demonstrating Terminator Python SDK
- document steps in README
- mention new example in root README

## Testing
- `cargo test` *(fails: failed to fetch uni-ocr dependency)*
- `npm test` *(fails: package.json missing)*