### PR TITLE
Add CI build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build workspace
+        run: cargo build --workspace --verbose


### PR DESCRIPTION
## Summary
- add `ci.yml` workflow to compile the Rust workspace on Mac and Windows

## Testing
- `cargo check` *(fails: failed to clone git dependency)*
- `cargo fmt --all -- --check` *(fails: `cargo-fmt` is not installed)*