### PR TITLE
remove async from Desktop::new

### DIFF
--- a/bindings/nodejs/src/desktop.rs
+++ b/bindings/nodejs/src/desktop.rs
@@ -35,9 +35,7 @@ impl Desktop {
                 .with_env_filter(log_level)
                 .try_init();
         });
-        let rt = tokio::runtime::Runtime::new()
-            .expect("Failed to create Tokio runtime");
-        let desktop = rt.block_on(TerminatorDesktop::new(use_background_apps, activate_app))
+        let desktop = TerminatorDesktop::new(use_background_apps, activate_app)
             .expect("Failed to create Desktop instance");
         Desktop { inner: desktop }
     }

--- a/bindings/python/src/desktop.rs
+++ b/bindings/python/src/desktop.rs
@@ -45,9 +45,7 @@ impl Desktop {
         });
         let use_background_apps = use_background_apps.unwrap_or(false);
         let activate_app = activate_app.unwrap_or(false);
-        let desktop = tokio::runtime::Runtime::new()
-            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?
-            .block_on(TerminatorDesktop::new(use_background_apps, activate_app))
+        let desktop = TerminatorDesktop::new(use_background_apps, activate_app)
             .map_err(|e| automation_error_to_pyerr(e))?;
         Ok(Desktop { inner: desktop })
     }

--- a/examples/terminator-rust-examples/server/src/main.rs
+++ b/examples/terminator-rust-examples/server/src/main.rs
@@ -1665,7 +1665,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Starting Terminator server");
     let start = Instant::now();
 
-    let desktop = Arc::new(Desktop::new(false, false).await?);
+    let desktop = Arc::new(Desktop::new(false, false)?);
     let app_state = Arc::new(AppState::new(desktop));
 
     let app = Router::new()

--- a/examples/terminator-rust-examples/win_automation/src/main.rs
+++ b/examples/terminator-rust-examples/win_automation/src/main.rs
@@ -97,7 +97,7 @@ async fn main() -> Result<(), AutomationError> {
     // Or, just open notepad blank first, then finding the edit area and setting its value.
     // Let's try opening notepad blank first, then finding the edit area and setting its value.
     // let notepad_app = engine.open_application("notepad")?;
-    let desktop = Desktop::new(false, true).await.unwrap();
+    let desktop = Desktop::new(false, true).unwrap();
     // desktop.activate_browser_window_by_title("Excel")?;
     // let window = desktop.get_current_browser_window().await.unwrap();
     // println!("window: {:?}", window.attributes());

--- a/terminator/benches/element_tree_benchmarks.rs
+++ b/terminator/benches/element_tree_benchmarks.rs
@@ -10,7 +10,7 @@ struct BenchmarkData {
 
 impl BenchmarkData {
     async fn new() -> Result<Self, Box<dyn std::error::Error>> {
-        let desktop = Desktop::new(false, false).await?;
+        let desktop = Desktop::new(false, false)?;
         let root_element = desktop.root();
         
         // Collect some sample elements for benchmarking

--- a/terminator/benches/tree_performance_benchmarks.rs
+++ b/terminator/benches/tree_performance_benchmarks.rs
@@ -10,7 +10,7 @@ struct TreeBenchmarkData {
 
 impl TreeBenchmarkData {
     async fn new() -> Result<Self, Box<dyn std::error::Error>> {
-        let desktop = Desktop::new(false, false).await?;
+        let desktop = Desktop::new(false, false)?;
         let root_element = desktop.root();
         
         Ok(Self {

--- a/terminator/examples/advanced_window_targeting.rs
+++ b/terminator/examples/advanced_window_targeting.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), AutomationError> {
     println!("=================================\n");
     
     // Create desktop automation instance
-    let desktop = Desktop::new(false, false).await?;
+    let desktop = Desktop::new(false, false)?;
     
     // Get all applications and organize by PID
     let applications = desktop.applications()?;

--- a/terminator/examples/benchmark_example.rs
+++ b/terminator/examples/benchmark_example.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Initialize desktop automation
     let start = Instant::now();
-    let desktop = Desktop::new(false, false).await?;
+    let desktop = Desktop::new(false, false)?;
     println!("Desktop initialization: {:?}", start.elapsed());
 
     // Get root element

--- a/terminator/examples/list_processes_and_windows.rs
+++ b/terminator/examples/list_processes_and_windows.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), AutomationError> {
     info!("Starting process and window enumeration...");
     
     // Create desktop automation instance
-    let desktop = Desktop::new(false, false).await?;
+    let desktop = Desktop::new(false, false)?;
     
     // Get all applications
     let applications = desktop.applications()?;

--- a/terminator/examples/serialize_deserialize_element.rs
+++ b/terminator/examples/serialize_deserialize_element.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("==================================================");
     
     // Initialize the desktop automation
-    let desktop = Desktop::new(false, false).await?;
+    let desktop = Desktop::new(false, false)?;
     
     // Get the root element (desktop)
     let root = desktop.root();

--- a/terminator/examples/serialize_element.rs
+++ b/terminator/examples/serialize_element.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     // Initialize the desktop automation
     // Parameters: use_background_apps: bool, activate_app: bool
-    let desktop = Desktop::new(false, false).await?;
+    let desktop = Desktop::new(false, false)?;
     
     // Get the root element (desktop)
     let root = desktop.root();

--- a/terminator/examples/simple_process_list.rs
+++ b/terminator/examples/simple_process_list.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), AutomationError> {
     println!("Starting process and window enumeration...");
     
     // Create desktop automation instance
-    let desktop = Desktop::new(false, false).await?;
+    let desktop = Desktop::new(false, false)?;
     
     // Get all applications
     let applications = desktop.applications()?;

--- a/terminator/examples/smart_deserialize.rs
+++ b/terminator/examples/smart_deserialize.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=================================");
     
     // Initialize the desktop automation
-    let desktop = Desktop::new(false, false).await?;
+    let desktop = Desktop::new(false, false)?;
     
     // Get a live element and serialize it
     let live_element = desktop.root();

--- a/terminator/examples/uielement_deserialize.rs
+++ b/terminator/examples/uielement_deserialize.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=================================");
     
     // Initialize the desktop automation
-    let desktop = Desktop::new(false, false).await?;
+    let desktop = Desktop::new(false, false)?;
     
     // Get the root element and serialize it
     let root_element = desktop.root();

--- a/terminator/src/lib.rs
+++ b/terminator/src/lib.rs
@@ -65,7 +65,7 @@ pub struct Desktop {
 
 impl Desktop {
     #[instrument(skip(use_background_apps, activate_app))]
-    pub async fn new(
+    pub fn new(
         use_background_apps: bool,
         activate_app: bool,
     ) -> Result<Self, AutomationError> {

--- a/terminator/src/tests/e2e_tests.rs
+++ b/terminator/src/tests/e2e_tests.rs
@@ -117,7 +117,7 @@ async fn test_fill_edit_elements_direct() {
     
     // 1. Initialize Desktop automation
     info!("Initializing Desktop automation");
-    let desktop = Desktop::new(false, false).await.unwrap();
+    let desktop = Desktop::new(false, false).unwrap();
     
     // 2. Open the website
     info!("Opening URL: {}", TEST_URL);
@@ -233,7 +233,7 @@ async fn benchmark_find_edit_elements() {
 
     // 1. Initialize Desktop automation
     info!("(Direct) Initializing Desktop automation");
-    let desktop = Desktop::new(false, false).await.unwrap();
+    let desktop = Desktop::new(false, false).unwrap();
     
     // 2. Open the website
     info!("(Direct) Opening URL: {}", TEST_URL);

--- a/terminator/src/tests/firefox_window_tests.rs
+++ b/terminator/src/tests/firefox_window_tests.rs
@@ -6,7 +6,7 @@ use crate::tests::init_tracing;
 #[ignore]
 async fn test_get_firefox_window_tree() -> Result<(), AutomationError> {
     init_tracing();
-    let desktop = Desktop::new(false, true).await?;
+    let desktop = Desktop::new(false, true)?;
 
     // Try to find the Firefox window by title. 
     // This might need adjustment based on the actual window title.


### PR DESCRIPTION
@louis030195 the create_engine function is already sync , so therefore there is no need for Desktop::new() to be async.
using async , adds overhead to it , likely some milliseconds
