### PR TITLE
feat: Add Windows 10 VM setup with GUI application management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ __pycache__
 *.egg-info
 build/
 dist/
-
+.vagrant/
 
 .env 
 

--- a/examples/mspaint.py
+++ b/examples/mspaint.py
@@ -17,13 +17,7 @@ async def run_mspaint():
         print(f"Canvas bounds: {canvas_bounds}")
 
         # Restore original panel, tool_panel, and shapes_toolbar selectors
-        panel = (
-            paint_window.locator("Pane:UIRibbonDockTop")
-            .locator("Pane:Ribbon")
-            .locator("Pane:Ribbon")
-            .locator("Pane:Ribbon")
-            .locator("Pane:Ribbon")
-        )
+        panel = paint_window.locator("Pane:UIRibbonDockTop")
         tool_panel = panel.locator("Pane:Lower Ribbon")
         shapes_toolbar = tool_panel.locator("Name:Shapes")
 
@@ -79,14 +73,10 @@ async def run_mspaint():
             print(f"Selecting shape tool: {shape_name}")
             await click_more_shapes_button()
             await asyncio.sleep(0.2)
-            shapes_box = (
-                desktop.locator("window:Shapes")
-                .locator("window:Shapes")
-                .locator("List:Shapes")
-                .locator("Role:Custom")
-            )
-            tool = shapes_box.locator(f"Name:{shape_name}")
-            await tool.click()
+
+            shapes_box = desktop.locator("window:Shapes").locator("List:Shapes")
+            tool = await shapes_box.locator(f"Name:{shape_name}").first()
+            tool.click()
             await asyncio.sleep(0.5)
 
         async def select_brush(brush_name):
@@ -112,12 +102,8 @@ async def run_mspaint():
             )
             brushes_button.click()
             await asyncio.sleep(0.5)
-            brushes_group = (
-                paint_window.locator("window:Brushes")
-                .locator("List:Brushes")
-                .locator("Role:Custom")
-                .locator("Group:Brushes")
-            )
+
+            brushes_group = desktop.locator("List:Brushes")
             brush = await brushes_group.locator(f"Name:{brush_name}").first()
             brush.click()
             await asyncio.sleep(0.5)
@@ -239,7 +225,7 @@ async def run_mspaint():
 
         # Enter file name
         print("Entering file name...")
-        save_dialog = desktop.locator("window:Save As").locator("window:Save As")
+        save_dialog = paint_window.locator("window:Save As")
         file_name_edit_box = (
             await save_dialog.locator("role:Pane")
             .locator("role:ComboBox")

--- a/examples/notepad.py
+++ b/examples/notepad.py
@@ -130,9 +130,6 @@ async def run_notepad():
         except:
             pass
 
-        # close notepad
-        editor.close()
-
     except terminator.PlatformError as e:
         print(f"Platform Error: {e}")
     except Exception as e:

--- a/examples/notepad.py
+++ b/examples/notepad.py
@@ -51,7 +51,7 @@ async def run_notepad():
         document.press_key("{Ctrl}s")
 
         print("Entering file name...")
-        save_dialog = desktop.locator("window:Save As").locator("window:Save As")
+        save_dialog = editor.locator("window:Save As")
         save_dialog_window = await save_dialog.first()
         save_dialog_window.highlight(
             color=0xFF00FF, duration_ms=3000
@@ -129,6 +129,9 @@ async def run_notepad():
                     break
         except:
             pass
+
+        # close notepad
+        editor.close()
 
     except terminator.PlatformError as e:
         print(f"Platform Error: {e}")

--- a/examples/snipping_tool.py
+++ b/examples/snipping_tool.py
@@ -38,7 +38,7 @@ async def draw_polygon(
     x0 = center_x + radius * math.cos(angle0)
     y0 = center_y + radius * math.sin(angle0)
     app_window.mouse_click_and_hold(x0, y0)
-    asyncio.sleep(sleep_time)
+    await asyncio.sleep(sleep_time)
     for r in range(rounds):
         for i in range(1, sides + 1):
             angle = 2 * math.pi * i / sides
@@ -73,7 +73,7 @@ async def run_snipping_tool():
         await asyncio.sleep(1)
 
         print("Entering file name...")
-        save_dialog = desktop.locator("window:Save As").locator("window:Save As")
+        save_dialog = app_window.locator("window:Save As")
         file_name_edit_box = (
             await save_dialog.locator("role:Pane")
             .locator("role:ComboBox")

--- a/scripts/gui-launch.ps1
+++ b/scripts/gui-launch.ps1
@@ -20,10 +20,10 @@ param (
 )
 
 # PsExec path
-$psexec = Join-Path $env:ProgramFiles "PSTools\PsExec.exe"
+$psexec = (where.exe psexec).Split("`n")[0]
 
-if (-not (Test-Path $psexec)) {
-    Write-Error "PsExec not found at $psexec. Make sure PSTools is installed in Program Files."
+if (-not $psexec) {
+    Write-Error "PsExec not found. Make sure PSTools is installed and in PATH."
     exit 1
 }
 

--- a/scripts/gui-launch.ps1
+++ b/scripts/gui-launch.ps1
@@ -1,0 +1,107 @@
+<#
+.SYNOPSIS
+    Launch a GUI application from a non-interactive or SSH session in Windows using PsExec.
+
+.EXAMPLE
+    .\gui-launch.ps1 notepad.exe
+    .\gui-launch.ps1 "C:\Program Files\SomeApp\app.exe" /flag
+
+.OPTIONAL
+    To create a shortcut function, add this to your PowerShell profile:
+        function gui-launch { & "C:\Path\To\gui-launch.ps1" @args }
+    Then you can call:
+        gui-launch calc
+        gui-launch "C:\MyApp\something.exe" /with /args
+#>
+
+param (
+    [Parameter(Mandatory = $true, ValueFromRemainingArguments = $true)]
+    [string[]]$Command
+)
+
+# PsExec path
+$psexec = Join-Path $env:ProgramFiles "PSTools\PsExec.exe"
+
+if (-not (Test-Path $psexec)) {
+    Write-Error "PsExec not found at $psexec. Make sure PSTools is installed in Program Files."
+    exit 1
+}
+
+# Get current working directory (from where script is run)
+$currentDir = (Get-Location).Path
+
+# Resolve any relative paths in the command to absolute paths
+$Command = $Command | ForEach-Object {
+    if ($_ -match '^\.\\|^\./') {
+        # Remove the .\ or ./ prefix before joining paths
+        $relativePath = $_ -replace '^\.\\|^\./', ''
+        $fullPath = Join-Path $currentDir $relativePath
+        if (Test-Path $fullPath) {
+            $fullPath
+        } else {
+            $_
+        }
+    } else {
+        $_
+    }
+}
+
+# Get active session ID
+$activeSession = (query session | Where-Object { $_ -match 'Active' } | ForEach-Object { 
+    $parts = $_ -split '\s+' | Where-Object { $_ -ne '' }
+    $parts[2]  # ID is the third column
+})
+if (-not $activeSession) {
+    Write-Error "No active session found"
+    exit 1
+}
+
+# Use PowerShell wrapping when there are arguments
+$escapedCommand = $Command | ForEach-Object {
+    if ($_ -match '\s') {
+        "`"$_`""
+    } else {
+        $_
+    }
+}
+$escapedCommand = $escapedCommand -join ' '
+$escapedCommand = "`"$escapedCommand`""
+
+# Create a temporary file for output
+$tempFile = [System.IO.Path]::GetTempFileName()
+
+& $psexec -accepteula -h -d -i $activeSession -u vagrant -p vagrant -w $currentDir powershell.exe -WindowStyle Hidden -Command "conhost.exe --headless $escapedCommand 2>&1 | Tee-Object -FilePath $tempFile; Add-Content '$tempFile' '__END__'" *> $null
+
+# Function to sanitize log content by removing control characters and VT sequences
+function Remove-DangerousCharacters {
+    param([string]$Content)
+    # Remove OSC sequences (starting with ]0;)
+    $Content = $Content -replace '\]0;.*?\x07', ''
+    # Remove ANSI/VT escape sequences including clear screen, cursor positioning
+    $Content = $Content -replace '\x1B\[[0-9;]*[a-zA-Z]', ''
+    # Remove CSI sequences (starting with ESC[)
+    $Content = $Content -replace '\x1B\[[?]?[0-9;]*[a-zA-Z]', ''
+    # Remove character deletion sequences (like [27X)
+    $Content = $Content -replace '\[[0-9]+X', ''
+    # Remove other control characters except newlines and tabs
+    $Content = $Content -replace '[^\x20-\x7E\x0A\x09]', ''
+    return $Content
+}
+
+# Read and display the output
+if (Test-Path $tempFile) {
+    try {
+        Get-Content $tempFile -Wait | ForEach-Object {
+            if ($_ -eq '__END__') {
+                break
+            }
+            Remove-DangerousCharacters $_
+        }
+    }
+    finally {
+        # Clean up the temporary file
+        if (Test-Path $tempFile) {
+            Remove-Item $tempFile -Force
+        }
+    }
+}

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,162 @@
+# Terminator Development VM
+
+This directory contains the Vagrant configuration for setting up a Windows 10 development environment for the Terminator project.
+
+## Prerequisites
+
+- [Vagrant](https://www.vagrantup.com/downloads)
+- [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+
+## Configuration
+
+The VM is configured with:
+- Windows 10 as the base OS
+- 4GB RAM
+- 2 CPU cores
+- SSH access (port 2222)
+- The entire workspace is synced to `C:/Users/vagrant/terminator` in the VM
+- username - vagrant
+- password - vagrant
+
+## Usage
+
+1. Start the VM:
+   ```bash
+   vagrant up
+   ```
+
+2. Connect to the VM:
+   ```bash
+   vagrant ssh
+   ```
+
+3. The workspace will be available at `C:/Users/vagrant/terminator` inside the VM
+
+4. To stop the VM:
+   ```bash
+   vagrant halt
+   ```
+
+5. To destroy the VM and start fresh:
+   ```bash
+   vagrant destroy
+   ```
+
+## Remote Desktop (RDP) Connection
+
+You can connect to the VM using Remote Desktop Protocol (RDP) in two ways:
+
+### Quick Connection
+Simply run:
+```bash
+vagrant rdp
+```
+This will automatically launch your default RDP client with the correct connection details.
+
+### Manual Connection
+If you need the current RDP connection details (which may change between VM restarts), run:
+```bash
+vagrant winrm-config
+```
+
+You can then use any RDP client (like Windows Remote Desktop Connection or Remmina) to connect using the details from the command output.
+
+## VS Code / Cursor Remote SSH
+
+To use VS Code or Cursor with Remote SSH:
+
+1. First, add this entry to your SSH config file:
+
+   For Windows (PowerShell):
+   ```powershell
+   $sshConfig = @"
+   Host default
+     HostName 127.0.0.1
+     User vagrant
+     Port 2222
+     UserKnownHostsFile /dev/null
+     StrictHostKeyChecking no
+     LogLevel FATAL
+   "@
+   Add-Content -Path "$env:USERPROFILE\.ssh\config" -Value $sshConfig
+   ```
+
+   For macOS/Linux (Bash):
+   ```bash
+   cat << 'EOF' >> ~/.ssh/config
+   Host default
+     HostName 127.0.0.1
+     User vagrant
+     Port 2222
+     UserKnownHostsFile /dev/null
+     StrictHostKeyChecking no
+     LogLevel FATAL
+   EOF
+   ```
+
+   You can change the `Host` name from `default` to anything you prefer.
+
+2. Then connect using:
+   ```bash
+   code --remote ssh-remote+default C:/Users/vagrant/terminator
+   ```
+   Replace `default` with your chosen hostname if you changed it.
+
+   When prompted for a password, use: `vagrant`
+
+## Development Workflow
+
+1. The entire workspace is synced between your host machine and the VM
+2. Changes made on either side will be reflected on the other
+3. You can use your preferred IDE on the host machine while running the code in the VM
+
+## GUI Application Launching
+
+When working through SSH or non-interactive sessions, you can use the `gui-launch` function to start GUI applications in the active user session. This is particularly useful when you need to run Windows applications while connected via SSH or VS Code Remote SSH.
+
+### Usage
+
+1. Launch a simple application:
+   ```powershell
+   gui-launch notepad.exe
+   ```
+
+2. Launch an application with arguments:
+   ```powershell
+   gui-launch "C:\Program Files\SomeApp\app.exe" /flag
+   ```
+
+3. Launch Python scripts with GUI components:
+   ```powershell
+   gui-launch py .\terminator\examples\snipping_tool.py
+   ```
+
+4. Launch applications with relative paths:
+   ```powershell
+   gui-launch .\my_app\app.exe
+   ```
+
+5. Launch applications with complex arguments:
+   ```powershell
+   gui-launch "C:\Program Files\Microsoft VS Code\Code.exe" --new-window "C:\path\to\file.txt"
+   ```
+
+### Features
+- Automatically resolves relative paths to absolute paths
+- Handles commands with spaces and special characters
+- Runs applications in the active user session
+- Captures and displays command output
+- Works with both simple commands and complex command lines with arguments
+
+### Requirements
+- PSTools must be installed (automatically handled by the Vagrant setup)
+- Must be run from a PowerShell session
+- Requires an active user session on the Windows VM
+
+## Notes
+
+- The VM uses WinRM for initial setup and SSH for subsequent connections
+- Default credentials are:
+  - Username: vagrant
+  - Password: vagrant
+- SSH is configured to start automatically on boot 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,90 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  # Windows 10 box configuration
+  config.vm.box = "stromweld/windows-10"
+  
+  # VM resources
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 4096
+    vb.cpus = 2
+    vb.gui = true
+    vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"] # Enables a bidirectional clipboard between host and guest
+  end
+
+  # Network configuration
+  config.vm.network "forwarded_port", guest: 22, host: 2222, id: "ssh"
+
+  # WinRM configuration for initial setup
+  config.vm.communicator = "winrm"
+  config.winrm.username = "vagrant"
+  config.winrm.password = "vagrant"
+
+  # Sync the workspace
+  config.vm.synced_folder "..", "C:/Users/vagrant/terminator", type: "virtualbox"
+
+  # Combined provisioning script
+  config.vm.provision "shell", name: "full_setup", inline: <<-SHELL, privileged: true
+    Write-Host "Starting VM provisioning..." -ForegroundColor Green
+
+    # Setup PowerShell profile
+    Write-Host "Setting up PowerShell profile..." -ForegroundColor Yellow
+    $profilePath = "$env:USERPROFILE\\Documents\\WindowsPowerShell\\Microsoft.PowerShell_profile.ps1"
+    if (!(Test-Path $profilePath)) { New-Item -ItemType File -Path $profilePath -Force | Out-Null }
+    $scriptPath = 'C:/Users/vagrant/terminator/scripts/gui-launch.ps1'
+    Add-Content -Path $profilePath -Value "# gui-launch function"
+    Add-Content -Path $profilePath -Value "function gui-launch { & '$scriptPath' @args }"
+    Write-Host "PowerShell profile setup completed" -ForegroundColor Green
+
+    # Prevent shutdown: inject registry & power settings
+    Write-Host "Configuring power and shutdown settings..." -ForegroundColor Yellow
+    powercfg /change standby-timeout-ac 0
+    powercfg /change hibernate-timeout-ac 0
+    powercfg /change monitor-timeout-ac 0
+    reg add "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon" /v AutoLogonCount /t REG_DWORD /d 999 /f
+    reg add "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Power" /v HibernateEnabled /t REG_DWORD /d 0 /f
+    schtasks /Change /TN "\\Microsoft\\Windows\\UpdateOrchestrator\\Reboot" /Disable 2>$null
+    Start-Process -FilePath sc.exe -ArgumentList "config sppsvc start= disabled" -Wait
+    Stop-Service sppsvc
+    Write-Host "Power and shutdown settings configured" -ForegroundColor Green
+
+    # Setup SSH
+    Write-Host "Setting up SSH server..." -ForegroundColor Yellow
+    Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+    Start-Service sshd
+    Set-Service -Name sshd -StartupType 'Automatic'
+    
+    # Configure firewall for SSH
+    if (!(Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP")) {
+      New-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -DisplayName "OpenSSH Server (sshd) inbound" -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+    }
+    Write-Host "SSH server setup completed" -ForegroundColor Green
+
+    # Install Scoop and tools
+    Write-Host "Installing Scoop package manager..." -ForegroundColor Yellow
+    iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
+    Write-Host "Scoop installation completed" -ForegroundColor Green
+
+    # Install PSTools
+    Write-Host "Installing PSTools..." -ForegroundColor Yellow
+    scoop bucket add sysinternals
+    scoop install sysinternals/pstools
+    Write-Host "PSTools installation completed" -ForegroundColor Green
+
+    # Install Git
+    Write-Host "Installing Git..." -ForegroundColor Yellow
+    scoop install git
+    reg import "C:\\Users\\vagrant\\scoop\\apps\\git\\current\\install-context.reg"
+    reg import "C:\\Users\\vagrant\\scoop\\apps\\git\\current\\install-file-associations.reg"
+    Write-Host "Git installation completed" -ForegroundColor Green
+
+    # Install Python
+    Write-Host "Installing Python..." -ForegroundColor Yellow
+    scoop install python
+    reg import "C:\\Users\\vagrant\\scoop\\apps\\python\\current\\install-pep-514.reg"
+    Write-Host "Python installation completed" -ForegroundColor Green
+
+    Write-Host "VM provisioning completed successfully!" -ForegroundColor Green
+  SHELL
+end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -31,7 +31,9 @@ Vagrant.configure("2") do |config|
     # Setup PowerShell profile
     Write-Host "Setting up PowerShell profile..." -ForegroundColor Yellow
     $profilePath = "$env:USERPROFILE\\Documents\\WindowsPowerShell\\Microsoft.PowerShell_profile.ps1"
-    if (!(Test-Path $profilePath)) { New-Item -ItemType File -Path $profilePath -Force | Out-Null }
+    if (!(Test-Path $profilePath)) { 
+      New-Item -ItemType File -Path $profilePath -Force | Out-Null 
+    }
     $scriptPath = 'C:/Users/vagrant/terminator/scripts/gui-launch.ps1'
     Add-Content -Path $profilePath -Value "# gui-launch function"
     Add-Content -Path $profilePath -Value "function gui-launch { & '$scriptPath' @args }"
@@ -44,46 +46,43 @@ Vagrant.configure("2") do |config|
     powercfg /change monitor-timeout-ac 0
     reg add "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon" /v AutoLogonCount /t REG_DWORD /d 999 /f
     reg add "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Power" /v HibernateEnabled /t REG_DWORD /d 0 /f
-    schtasks /Change /TN "\\Microsoft\\Windows\\UpdateOrchestrator\\Reboot" /Disable 2>$null
     Start-Process -FilePath sc.exe -ArgumentList "config sppsvc start= disabled" -Wait
+    Sleep 2
     Stop-Service sppsvc
     Write-Host "Power and shutdown settings configured" -ForegroundColor Green
 
-    # Setup SSH
-    Write-Host "Setting up SSH server..." -ForegroundColor Yellow
-    Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
-    Start-Service sshd
-    Set-Service -Name sshd -StartupType 'Automatic'
-    
-    # Configure firewall for SSH
-    if (!(Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP")) {
-      New-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -DisplayName "OpenSSH Server (sshd) inbound" -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
-    }
-    Write-Host "SSH server setup completed" -ForegroundColor Green
+    # Install OpenSSH
+    Write-Host "Installing OpenSSH..." -ForegroundColor Yellow
+    $scriptPath = 'C:/Users/vagrant/terminator/vagrant/install-openssh.ps1'
+    PowerShell -ExecutionPolicy Bypass -File $scriptPath
+    Write-Host "OpenSSH installation completed" -ForegroundColor Green
 
     # Install Scoop and tools
     Write-Host "Installing Scoop package manager..." -ForegroundColor Yellow
     iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
     Write-Host "Scoop installation completed" -ForegroundColor Green
 
-    # Install PSTools
-    Write-Host "Installing PSTools..." -ForegroundColor Yellow
-    scoop bucket add sysinternals
-    scoop install sysinternals/pstools
-    Write-Host "PSTools installation completed" -ForegroundColor Green
-
     # Install Git
     Write-Host "Installing Git..." -ForegroundColor Yellow
     scoop install git
-    reg import "C:\\Users\\vagrant\\scoop\\apps\\git\\current\\install-context.reg"
-    reg import "C:\\Users\\vagrant\\scoop\\apps\\git\\current\\install-file-associations.reg"
+    sleep 1
+    reg import "C:\Users\vagrant\scoop\apps\7zip\current\install-context.reg"
+    reg import "C:\Users\vagrant\scoop\apps\git\current\install-context.reg"
+    reg import "C:\Users\vagrant\scoop\apps\git\current\install-file-associations.reg"
     Write-Host "Git installation completed" -ForegroundColor Green
 
     # Install Python
     Write-Host "Installing Python..." -ForegroundColor Yellow
     scoop install python
-    reg import "C:\\Users\\vagrant\\scoop\\apps\\python\\current\\install-pep-514.reg"
+    sleep 1
+    reg import "C:\Users\vagrant\scoop\apps\python\current\install-pep-514.reg"
     Write-Host "Python installation completed" -ForegroundColor Green
+    
+    # Install PSTools
+    Write-Host "Installing PSTools..." -ForegroundColor Yellow
+    scoop bucket add sysinternals
+    scoop install sysinternals/pstools
+    Write-Host "PSTools installation completed" -ForegroundColor Green
 
     Write-Host "VM provisioning completed successfully!" -ForegroundColor Green
   SHELL

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -4,13 +4,14 @@
 Vagrant.configure("2") do |config|
   # Windows 10 box configuration
   config.vm.box = "stromweld/windows-10"
-  
+
   # VM resources
   config.vm.provider "virtualbox" do |vb|
     vb.memory = 4096
     vb.cpus = 2
     vb.gui = true
-    vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"] # Enables a bidirectional clipboard between host and guest
+    # Enables a bidirectional clipboard between host and guest
+    vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
   end
 
   # Network configuration
@@ -26,64 +27,86 @@ Vagrant.configure("2") do |config|
 
   # Combined provisioning script
   config.vm.provision "shell", name: "full_setup", inline: <<-SHELL, privileged: true
-    Write-Host "Starting VM provisioning..." -ForegroundColor Green
+      Write-Host "Starting VM provisioning..." -ForegroundColor Green
 
-    # Setup PowerShell profile
-    Write-Host "Setting up PowerShell profile..." -ForegroundColor Yellow
-    $profilePath = "$env:USERPROFILE\\Documents\\WindowsPowerShell\\Microsoft.PowerShell_profile.ps1"
-    if (!(Test-Path $profilePath)) { 
-      New-Item -ItemType File -Path $profilePath -Force | Out-Null 
-    }
-    $scriptPath = 'C:/Users/vagrant/terminator/scripts/gui-launch.ps1'
-    Add-Content -Path $profilePath -Value "# gui-launch function"
-    Add-Content -Path $profilePath -Value "function gui-launch { & '$scriptPath' @args }"
-    Write-Host "PowerShell profile setup completed" -ForegroundColor Green
+      # Setup PowerShell profile
+      Write-Host "Setting up PowerShell profile..." -ForegroundColor Yellow
+      $profilePath = "$env:USERPROFILE\\Documents\\WindowsPowerShell\\Microsoft.PowerShell_profile.ps1"
+      if (!(Test-Path $profilePath)) {
+        New-Item -ItemType File -Path $profilePath -Force | Out-Null
+      }
+      $scriptPath = 'C:/Users/vagrant/terminator/scripts/gui-launch.ps1'
+      Add-Content -Path $profilePath -Value "# gui-launch function"
+      Add-Content -Path $profilePath -Value "function gui-launch { & '$scriptPath' @args }"
+      Write-Host "PowerShell profile setup completed" -ForegroundColor Green
 
-    # Prevent shutdown: inject registry & power settings
-    Write-Host "Configuring power and shutdown settings..." -ForegroundColor Yellow
-    powercfg /change standby-timeout-ac 0
-    powercfg /change hibernate-timeout-ac 0
-    powercfg /change monitor-timeout-ac 0
-    reg add "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon" /v AutoLogonCount /t REG_DWORD /d 999 /f
-    reg add "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Power" /v HibernateEnabled /t REG_DWORD /d 0 /f
-    Start-Process -FilePath sc.exe -ArgumentList "config sppsvc start= disabled" -Wait
-    Sleep 2
-    Stop-Service sppsvc
-    Write-Host "Power and shutdown settings configured" -ForegroundColor Green
+      # Prevent shutdown: inject registry & power settings
+      Write-Host "Configuring power and shutdown settings..." -ForegroundColor Yellow
+      powercfg /change standby-timeout-ac 0
+      powercfg /change hibernate-timeout-ac 0
+      powercfg /change monitor-timeout-ac 0
+      reg add "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon" /v AutoLogonCount /t REG_DWORD /d 999 /f
+      reg add "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Power" /v HibernateEnabled /t REG_DWORD /d 0 /f
 
-    # Install OpenSSH
-    Write-Host "Installing OpenSSH..." -ForegroundColor Yellow
-    $scriptPath = 'C:/Users/vagrant/terminator/vagrant/install-openssh.ps1'
-    PowerShell -ExecutionPolicy Bypass -File $scriptPath
-    Write-Host "OpenSSH installation completed" -ForegroundColor Green
+      # Step 1: Disable the service
+      Start-Process -FilePath sc.exe -ArgumentList "config sppsvc start= disabled" -Wait
+      Start-Sleep -Seconds 2
 
-    # Install Scoop and tools
-    Write-Host "Installing Scoop package manager..." -ForegroundColor Yellow
-    iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
-    Write-Host "Scoop installation completed" -ForegroundColor Green
+      # Step 2: Try stopping it up to 3 times
+      for ($i = 1; $i -le 3; $i++) {
+        try {
+          Write-Output "Try #$i: Stopping sppsvc..."
+          Stop-Service sppsvc -Force -ErrorAction Stop
+          Write-Output "sppsvc stopped successfully."
+          break
+        } catch {
+          Write-Warning "Attempt #$i failed: $($_.Exception.Message)"
+          Start-Sleep -Seconds 2
+        }
+      }
 
-    # Install Git
-    Write-Host "Installing Git..." -ForegroundColor Yellow
-    scoop install git
-    sleep 1
-    reg import "C:\Users\vagrant\scoop\apps\7zip\current\install-context.reg"
-    reg import "C:\Users\vagrant\scoop\apps\git\current\install-context.reg"
-    reg import "C:\Users\vagrant\scoop\apps\git\current\install-file-associations.reg"
-    Write-Host "Git installation completed" -ForegroundColor Green
+      # Step 3: If still running, kill it
+      $sppsvc = Get-Process sppsvc -ErrorAction SilentlyContinue
+      if ($sppsvc) {
+        Write-Warning "sppsvc still running after 3 attempts, killing it..."
+        Stop-Process -Id $sppsvc.Id -Force
+      }
 
-    # Install Python
-    Write-Host "Installing Python..." -ForegroundColor Yellow
-    scoop install python
-    sleep 1
-    reg import "C:\Users\vagrant\scoop\apps\python\current\install-pep-514.reg"
-    Write-Host "Python installation completed" -ForegroundColor Green
-    
-    # Install PSTools
-    Write-Host "Installing PSTools..." -ForegroundColor Yellow
-    scoop bucket add sysinternals
-    scoop install sysinternals/pstools
-    Write-Host "PSTools installation completed" -ForegroundColor Green
+      Write-Host "Power and shutdown settings configured" -ForegroundColor Green
 
-    Write-Host "VM provisioning completed successfully!" -ForegroundColor Green
-  SHELL
+      # Install OpenSSH
+      Write-Host "Installing OpenSSH..." -ForegroundColor Yellow
+      $scriptPath = 'C:/Users/vagrant/terminator/vagrant/install-openssh.ps1'
+      PowerShell -ExecutionPolicy Bypass -File $scriptPath
+      Write-Host "OpenSSH installation completed" -ForegroundColor Green
+
+      # Install Scoop and tools
+      Write-Host "Installing Scoop package manager..." -ForegroundColor Yellow
+      iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
+      Write-Host "Scoop installation completed" -ForegroundColor Green
+
+      # Install Git
+      Write-Host "Installing Git..." -ForegroundColor Yellow
+      scoop install git
+      sleep 1
+      reg import "C:\Users\vagrant\scoop\apps\7zip\current\install-context.reg"
+      reg import "C:\Users\vagrant\scoop\apps\git\current\install-context.reg"
+      reg import "C:\Users\vagrant\scoop\apps\git\current\install-file-associations.reg"
+      Write-Host "Git installation completed" -ForegroundColor Green
+
+      # Install Python
+      Write-Host "Installing Python..." -ForegroundColor Yellow
+      scoop install python
+      sleep 1
+      reg import "C:\Users\vagrant\scoop\apps\python\current\install-pep-514.reg"
+      Write-Host "Python installation completed" -ForegroundColor Green
+
+      # Install PSTools
+      Write-Host "Installing PSTools..." -ForegroundColor Yellow
+      scoop bucket add sysinternals
+      scoop install sysinternals/pstools
+      Write-Host "PSTools installation completed" -ForegroundColor Green
+
+      Write-Host "VM provisioning completed successfully!" -ForegroundColor Green
+    SHELL
 end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -12,6 +12,7 @@ Vagrant.configure("2") do |config|
     vb.gui = true
     # Enables a bidirectional clipboard between host and guest
     vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+    vb.customize ["modifyvm", :id, "--monitorcount", "3"]
   end
 
   # Network configuration

--- a/vagrant/install-openssh.ps1
+++ b/vagrant/install-openssh.ps1
@@ -1,0 +1,154 @@
+#Configure Variables
+$InstallPath = "C:\Program Files\OpenSSH"
+$DisablePasswordAuthentication = $false
+$DisablePubkeyAuthentication = $True
+$AutoStartSSHD = $true
+$AutoStartSSHAGENT = $true
+
+$OpenSSHLocation = $null
+$GitUrl = 'https://github.com/PowerShell/Win32-OpenSSH/releases/download/v8.1.0.0p1-Beta/OpenSSH-Win64.zip'
+$GitZipName = "OpenSSH-Win64.zip"
+$ErrorActionPreference = "Stop" # Do not change this one!
+$UserAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+
+# Detect Elevation:
+$CurrentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+$UserPrincipal = New-Object System.Security.Principal.WindowsPrincipal($CurrentUser)
+$AdminRole = [System.Security.Principal.WindowsBuiltInRole]::Administrator
+$IsAdmin = $UserPrincipal.IsInRole($AdminRole)
+if ($IsAdmin) {
+    Write-Host "Script is running elevated." -ForegroundColor Green
+}
+else {
+    throw "Script is not running elevated, which is required. Restart the script from an elevated prompt."
+}
+
+#Remove BuiltIn OpenSSH
+$ErrorActionPreference = "SilentlyContinue"
+Write-Host "Checking for Windows OpenSSH Server" -ForegroundColor Green
+if ($(Get-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0).State -eq "Installed") {
+    Write-Host "Removing Windows OpenSSH Server" -ForegroundColor Green
+    Remove-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 -ErrorAction SilentlyContinue
+}
+Write-Host "Checking for Windows OpenSSH Client" -ForegroundColor Green
+if ($(Get-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0).State -eq "Installed") {
+    Write-Host "Removing Windows OpenSSH Client" -ForegroundColor Green
+    Remove-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0 -ErrorAction SilentlyContinue
+}
+$ErrorActionPreference = "Stop"
+
+#Stop and remove existing services (Perhaps an exisitng OpenSSH install)
+if (Get-Service sshd -ErrorAction SilentlyContinue) {
+    Stop-Service sshd -ErrorAction SilentlyContinue
+    sc.exe delete sshd 1>$null
+}
+if (Get-Service ssh-agent -ErrorAction SilentlyContinue) {
+    Stop-Service ssh-agent -ErrorAction SilentlyContinue
+    sc.exe delete ssh-agent 1>$null
+}
+
+if ($OpenSSHLocation.Length -eq 0) {
+    # Download and extract archive
+    Write-Host "Downloading Archive" -ForegroundColor Green
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest -Uri $GitUrl -OutFile $GitZipName -ErrorAction Stop -TimeoutSec 5 -Headers @{"Pragma" = "no-cache"; "Cache-Control" = "no-cache"; } -UserAgent $UserAgent
+    Write-Host "Download Complete, now expanding and copying to destination" -ForegroundColor Green -ErrorAction Stop
+}
+else {
+    $PathInfo = [System.Uri]([string]::":FileSystem::" + $OpenSSHLocation)
+    if ($PathInfo.IsUnc) {
+        Copy-Item -Path $PathInfo.LocalPath -Destination $env:TEMP
+        Set-Location $env:TEMP
+    }
+}
+
+Remove-Item -Path $InstallPath -Force -Recurse -ErrorAction SilentlyContinue
+If (!(Test-Path $InstallPath)) {
+    New-Item -Path $InstallPath -ItemType "directory" -ErrorAction Stop | Out-Null
+}
+
+$OldEnv = [Environment]::CurrentDirectory
+[Environment]::CurrentDirectory = $(Get-Location)
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$archive = [System.IO.Compression.ZipFile]::OpenRead($GitZipName)
+$archive.Entries | ForEach-Object {
+    # Entries with an empty Name property are directories
+    if ($_.Name -ne '') {
+        $NewFIleName = Join-Path $InstallPath $_.Name
+        Remove-Item -Path $NewFIleName -Force -ErrorAction SilentlyContinue
+        [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, $NewFIleName)
+    }
+}
+$archive.Dispose()
+Set-Location $OldEnv
+
+#Cleanup zip file if we downloaded it
+if ($GitUrl.Length -gt 0) { Remove-Item -Path $GitZipName -Force -ErrorAction SilentlyContinue }
+
+#Run Install Script
+Write-Host "Running Install Commands" -ForegroundColor Green
+Set-Location $InstallPath -ErrorAction Stop
+powershell.exe -ExecutionPolicy Bypass -File install-sshd.ps1
+Set-Service -Name sshd -StartupType 'Automatic' -ErrorAction Stop
+
+#Make sure your ProgramData\ssh directory exists
+If (!(Test-Path $env:ProgramData\ssh)) {
+    Write-Host "Creating ProgramData\ssh directory" -ForegroundColor Green
+    New-Item -ItemType Directory -Force -Path $env:ProgramData\ssh -ErrorAction Stop | Out-Null
+}
+
+#Setup sshd_config
+Write-Host "Configure server config file" -ForegroundColor Green
+Copy-Item -Path $InstallPath\sshd_config_default -Destination $env:ProgramData\ssh\sshd_config -Force -ErrorAction Stop
+Add-Content -Path $env:ProgramData\ssh\sshd_config -Value "`r`nGSSAPIAuthentication yes" -ErrorAction Stop
+if ($DisablePasswordAuthentication) { Add-Content -Path $env:ProgramData\ssh\sshd_config -Value "PasswordAuthentication no" -ErrorAction Stop }
+if ($DisablePubkeyAuthentication) { Add-Content -Path $env:ProgramData\ssh\sshd_config -Value "PubkeyAuthentication no" -ErrorAction Stop }
+
+#Make sure your user .ssh directory exists
+If (!(Test-Path "~\.ssh")) {
+    Write-Host "Creating User .ssh directory" -ForegroundColor Green
+    New-Item -ItemType Directory -Force -Path "~\.ssh" -ErrorAction Stop | Out-Null
+}
+
+#Set ssh_config
+Write-Host "Configure client config file" -ForegroundColor Green
+Add-Content -Path ~\.ssh\config -Value "`r`nGSSAPIAuthentication yes" -ErrorAction Stop
+
+#Setting autostarts
+if ($AutoStartSSHD) {
+    Write-Host "Setting sshd service to Automatic start" -ForegroundColor Green;
+    Set-Service -Name sshd -StartupType Automatic;
+}
+if ($AutoStartSSHAGENT) {
+    Write-Host "Setting ssh-agent service to Automatic start" -ForegroundColor Green;
+    Set-Service -Name ssh-agent -StartupType Automatic;
+}
+
+#Start the service
+Write-Host "Starting sshd Service" -ForegroundColor Green
+Start-Service sshd -ErrorAction Stop
+
+#Add to path if it isnt already there
+$existingPath = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).path
+if ($existingPath -notmatch $InstallPath.Replace("\", "\\")) {
+    Write-Host "Adding OpenSSH Directory to path" -ForegroundColor Green
+    $newpath = "$existingPath;$InstallPath"
+    Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath -ErrorAction Stop
+}
+
+#Make sure user keys are configured correctly
+Write-Host "Ensuring HostKey file permissions are correct" -ForegroundColor Green
+powershell.exe -ExecutionPolicy Bypass -Command '. .\FixHostFilePermissions.ps1 -Confirm:$false'
+
+#Make sure host keys are configured correctly
+Write-Host "Ensuring UserKey file permissions are correct" -ForegroundColor Green
+powershell.exe -ExecutionPolicy Bypass -Command '. .\FixUserFilePermissions.ps1 -Confirm:$false'
+
+#Add firewall rule
+Write-Host "Creating firewall rule" -ForegroundColor Green
+New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 -ErrorAction SilentlyContinue
+
+#Set Shell to powershell
+Write-Host "Setting default shell to powershell" -ForegroundColor Green
+New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force -ErrorAction Stop | Out-Null
+Write-Host "Installation completed successfully" -ForegroundColor Green 

--- a/vagrant/install-openssh.ps1
+++ b/vagrant/install-openssh.ps1
@@ -5,6 +5,14 @@ $DisablePubkeyAuthentication = $True
 $AutoStartSSHD = $true
 $AutoStartSSHAGENT = $true
 
+# Prevent re-installation if already installed
+$sshdPath = Join-Path $InstallPath 'sshd.exe'
+$sshPath = Join-Path $InstallPath 'ssh.exe'
+if ((Test-Path $sshdPath) -and (Test-Path $sshPath)) {
+    Write-Host "OpenSSH is already installed at $InstallPath. Skipping installation." -ForegroundColor Yellow
+    return
+}
+
 $OpenSSHLocation = $null
 $GitUrl = 'https://github.com/PowerShell/Win32-OpenSSH/releases/download/v8.1.0.0p1-Beta/OpenSSH-Win64.zip'
 $GitZipName = "OpenSSH-Win64.zip"


### PR DESCRIPTION
## Key Features
- **Automated VM Setup**: Windows 10 environment with 4GB RAM and 2 CPU cores
- **GUI Application Management**: `gui-launch` script for running GUI apps in non-interactive sessions
- **Remote Development Support**: 
  - SSH access (port 2222)
  - RDP connection support
  - VS Code/Cursor Remote SSH integration
- **Pre-installed Tools**:
  - Git
  - Python
  - PSTools
  - Scoop package manager

### Development
The setup is particularly useful for development scenarios where you want to:
- Keep your development environment isolated
- Avoid GUI interruptions during coding sessions
- Use remote development tools while maintaining access to Windows-specific features

## Testing
1. Run `vagrant up` to create the VM
2. Connect using either:
   - `vagrant ssh` for SSH access
   - `vagrant rdp` for RDP access
3. Test the `gui-launch` function with various applications