### PR TITLE
add example for .monitor()

### DIFF
--- a/bindings/nodejs/index.d.ts
+++ b/bindings/nodejs/index.d.ts
@@ -23,10 +23,25 @@ export interface CommandOutput {
   stdout: string
   stderr: string
 }
+export interface Monitor {
+  id: string
+  name: string
+  isPrimary: boolean
+  width: number
+  height: number
+  x: number
+  y: number
+  scaleFactor: number
+}
+export interface MonitorScreenshotPair {
+  monitor: Monitor
+  screenshot: ScreenshotResult
+}
 export interface ScreenshotResult {
   width: number
   height: number
   imageData: Array<number>
+  monitor?: Monitor
 }
 export interface UIElementAttributes {
   role: string
@@ -194,7 +209,7 @@ export declare class Desktop {
    * Open a URL in a browser.
    *
    * @param {string} url - The URL to open.
-   * @param {string} [browser] - The browser to use.
+   * @param {string} [browser] - The browser to use. Can be "Default", "Chrome", "Firefox", "Edge", "Brave", "Opera", "Vivaldi", "Arc", or a custom browser path.
    */
   openUrl(url: string, browser?: string | undefined | null): Element
   /**
@@ -218,6 +233,51 @@ export declare class Desktop {
    * @returns {UINode} Complete UI tree starting from the identified window.
    */
   getWindowTree(pid: number, title?: string | undefined | null, config?: TreeBuildConfig | undefined | null): UINode
+  /**
+   * (async) List all available monitors/displays.
+   *
+   * @returns {Promise<Array<Monitor>>} List of monitor information.
+   */
+  listMonitors(): Promise<Array<Monitor>>
+  /**
+   * (async) Get the primary monitor.
+   *
+   * @returns {Promise<Monitor>} Primary monitor information.
+   */
+  getPrimaryMonitor(): Promise<Monitor>
+  /**
+   * (async) Get the monitor containing the currently focused window.
+   *
+   * @returns {Promise<Monitor>} Active monitor information.
+   */
+  getActiveMonitor(): Promise<Monitor>
+  /**
+   * (async) Get a monitor by its ID.
+   *
+   * @param {string} id - The monitor ID to find.
+   * @returns {Promise<Monitor>} Monitor information.
+   */
+  getMonitorById(id: string): Promise<Monitor>
+  /**
+   * (async) Get a monitor by its name.
+   *
+   * @param {string} name - The monitor name to find.
+   * @returns {Promise<Monitor>} Monitor information.
+   */
+  getMonitorByName(name: string): Promise<Monitor>
+  /**
+   * (async) Capture a screenshot of a specific monitor.
+   *
+   * @param {Monitor} monitor - The monitor to capture.
+   * @returns {Promise<ScreenshotResult>} The screenshot data.
+   */
+  captureMonitor(monitor: Monitor): Promise<ScreenshotResult>
+  /**
+   * (async) Capture screenshots of all monitors.
+   *
+   * @returns {Promise<Array<{monitor: Monitor, screenshot: ScreenshotResult}>>} Array of monitor and screenshot pairs.
+   */
+  captureAllMonitors(): Promise<Array<MonitorScreenshotPair>>
 }
 /** A UI element in the accessibility tree. */
 export declare class Element {
@@ -431,6 +491,12 @@ export declare class Element {
    * @returns {void}
    */
   close(): void
+  /**
+   * Get the monitor containing this element.
+   *
+   * @returns {Monitor} The monitor information for the display containing this element.
+   */
+  monitor(): Monitor
 }
 /** Locator for finding UI elements by selector. */
 export declare class Locator {

--- a/bindings/nodejs/src/element.rs
+++ b/bindings/nodejs/src/element.rs
@@ -412,4 +412,15 @@ impl Element {
     pub fn close(&self) -> napi::Result<()> {
         self.inner.close().map_err(map_error)
     }
+
+    /// Get the monitor containing this element.
+    ///
+    /// @returns {Monitor} The monitor information for the display containing this element.
+    #[napi]
+    pub fn monitor(&self) -> napi::Result<crate::types::Monitor> {
+        self.inner
+            .monitor()
+            .map(crate::types::Monitor::from)
+            .map_err(map_error)
+    }
 }

--- a/bindings/python/src/element.rs
+++ b/bindings/python/src/element.rs
@@ -508,4 +508,16 @@ impl UIElement {
     pub fn close(&self) -> PyResult<()> {
         self.inner.close().map_err(automation_error_to_pyerr)
     }
+
+    #[pyo3(name = "monitor", text_signature = "($self)")]
+    /// Get the monitor containing this element.
+    ///
+    /// Returns:
+    ///     Monitor: The monitor information for the display containing this element.
+    pub fn monitor(&self) -> PyResult<crate::types::Monitor> {
+        self.inner
+            .monitor()
+            .map(crate::types::Monitor::from)
+            .map_err(automation_error_to_pyerr)
+    }
 }

--- a/examples/monitor_example.py
+++ b/examples/monitor_example.py
@@ -1,0 +1,36 @@
+import asyncio
+import terminator
+
+async def main():
+    desktop = terminator.Desktop(log_level="error")
+
+    # Try to find a window element to get monitor info
+    locator = desktop.locator('role:Window')
+    try:
+        windows = await locator.all()
+        if not windows:
+            print("No windows found.")
+        for idx, window in enumerate(windows):
+            print(f"Found window {idx+1}: {window.name() or 'Unnamed window'}")
+            # Get monitor information for the window
+            monitor = window.monitor()
+            print("\nMonitor information:")
+            print(f"Name: {monitor.name}")
+            print(f"ID: {monitor.id}")
+            print(f"Position: ({monitor.x}, {monitor.y})")
+            print("-" * 10)
+
+        # You can also get monitor info for any UI element
+        # For example, let's find a button and get its monitor
+        button_locator = desktop.locator('role:Button')
+        button = await button_locator.first()
+        if button:
+            print("\nFound button:", button.name() or "Unnamed button")
+            button_monitor = button.monitor()
+            print(f"Button is on monitor: {button_monitor.name}")
+
+    except Exception as e:
+        print("Error:", str(e))
+
+if __name__ == "__main__":
+    asyncio.run(main()) 


### PR DESCRIPTION
@louis030195 I tested it on the vagrant box , it also has multi montor feature using virtual box settings

![Image](https://github.com/user-attachments/assets/ba786b79-2aad-4095-a498-5ed578800a60)

```bash
C:\Users\vagrant\terminator>python examples\monitor_example.py
Found window 1: Administrator: C:\Windows\system32\conhost.exe - python  examples\monitor_example.py

Monitor information:
Name: Unknown Monitor 65537
ID: monitor_0
Position: (0, 0)
----------
Found window 2: monitor on 1.txt - Notepad

Monitor information:
Name: Unknown Monitor 65537
ID: monitor_0
Position: (0, 0)
----------
Found window 3: monitor on 2.txt - Notepad

Monitor information:
Name: Unknown Monitor 65539
ID: monitor_1
Position: (955, 0)
----------
Found window 4: monitor on 3.txt - Notepad

Monitor information:
Name: Unknown Monitor 65541
ID: monitor_2
Position: (1910, 0)
----------

C:\Users\vagrant\terminator>
```

closes #122
