### PR TITLE
docs(readme): clarify pip install behavior with normalized package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ https://github.com/user-attachments/assets/00329105-8875-48cb-8970-a62a85a9ebd0
 ### 🐍 Python
 
 ```bash
-pip install terminator-py
+pip install terminator.py
 ```
 
 ```python


### PR DESCRIPTION
Use `pip install terminator.py` in docs instead of `terminator-py`, to align with naming conventions similar to `terminator.js` on NPM. Note that pip treats `-`, `_`, and `.` as equivalent per PEP 503, so all variants are valid.

![image](https://github.com/user-attachments/assets/8308594e-78e5-4de7-b628-4e29f2f3b836)
