### PR TITLE
CI workflows for Linux to build wheels, npm packages

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -12,26 +12,58 @@ permissions:
   attestations: write
 
 jobs:
-  # linux-x64:
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: 3.x
-  #     - name: Build wheels
-  #       uses: PyO3/maturin-action@v1
-  #       with:
-  #         working-directory: bindings/python
-  #         target: x86_64
-  #         args: --release --strip --out dist
-  #         sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-  #         manylinux: auto
-  #     - name: Upload wheels
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: wheels-linux-x86_64
-  #         path: bindings/python/dist
+  linux-x64:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Linux dependencies
+        run: bash scripts/install_linux_deps.sh
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          cache: true
+          target: x86_64-unknown-linux-gnu
+          rustflags: ""
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          architecture: x64
+
+      - name: Generate stubs
+        run: |
+          cargo run --bin stub_gen
+        working-directory: bindings/python
+
+      - name: Build wheels with system deps
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: bindings/python
+          target: x86_64
+          manylinux: '2_34'
+          args: --release --strip --out dist
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          before-script-linux: |
+            dnf install -y epel-release
+            dnf install -y \
+              pipewire-devel \
+              libxkbcommon-devel \
+              systemd-devel \
+              dbus-devel \
+              openssl-devel \
+              mesa-libEGL-devel \
+              mesa-libgbm-devel \
+              clang-devel \
+              llvm-devel \
+              wayland-devel
+      
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-x86_64
+          path: bindings/python/dist
 
   windows-x64:
     runs-on: windows-latest
@@ -146,9 +178,8 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
-    # Note: linux-x64 is commented out above; we do not support Linux wheels at the moment
     # TODO: enable mac [macos-x64, macos-arm64]
-    needs: [windows-x64]
+    needs: [windows-x64, linux-x64]
     permissions:
       id-token: write
       contents: write
@@ -170,4 +201,4 @@ jobs:
         with:
           working-directory: bindings/python
           command: upload
-          args: --non-interactive --skip-existing wheels-sdist/* wheels-windows-x64/*
+          args: --non-interactive --skip-existing wheels-sdist/* wheels-windows-x64/* wheels-linux-x86_64/*

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -16,7 +16,7 @@ jobs:
             bin_name: terminator-mcp-agent.exe
             npm_dir: win32-x64-msvc
 
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             bin_name: terminator-mcp-agent
             npm_dir: linux-x64-gnu
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Linux dependencies
-        if: matrix.settings.host == 'ubuntu-latest'
+        if: matrix.settings.host == 'ubuntu-22.04'
         run: bash scripts/install_linux_deps.sh
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -16,12 +16,12 @@ jobs:
               cd bindings/nodejs
               npm run build  
               cp terminator.win32-x64-msvc.node npm/win32-x64-msvc/
-          # - host: ubuntu-latest
-          #   target: x86_64-unknown-linux-gnu
-          #   build: |
-          #     cd bindings/nodejs
-          #     npm run build
-          #     cp terminator.linux-x64-gnu.node npm/linux-x64-gnu/
+          - host: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            build: |
+              cd bindings/nodejs
+              npm run build
+              cp terminator.linux-x64-gnu.node npm/linux-x64-gnu/
           - host: macos-latest
             target: x86_64-apple-darwin
             build: |
@@ -40,6 +40,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install Linux dependencies
+        if: matrix.settings.host == 'ubuntu-22.04'
+        run: bash scripts/install_linux_deps.sh
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/scripts/install_linux_deps.sh
+++ b/scripts/install_linux_deps.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+# fix: unable to compile libspa, related issue: https://github.com/pop-os/cosmic-epoch/issues/280
+sudo add-apt-repository ppa:pipewire-debian/pipewire-upstream
+
+# Disable interactive prompts (e.g. tzdata)
+export DEBIAN_FRONTEND=noninteractive
+
 # Install all required system dependencies for Linux build (from .devcontainer/Dockerfile)
 sudo apt-get update
 sudo apt-get install -y \


### PR DESCRIPTION
@louis030195 using ubuntu22 is better 
as it reduces the chance of glibc issues with other linux distros

I have also tested the workflows

--> python wheel
https://github.com/divanshu-go/terminator/actions/runs/15794129388?pr=2

--> npm binding
https://github.com/divanshu-go/terminator/actions/runs/15793380820