### PR TITLE
fix: getting all application

### DIFF
--- a/terminator/src/platforms/windows.rs
+++ b/terminator/src/platforms/windows.rs
@@ -4443,15 +4443,14 @@ fn get_application_pid(
                 }
             }
         }
-        // If all else fails, return an error instead of recursing
+        // If all else fails, try to find the application by name
         debug!(
-            "Failed to get application by PID {} and child PID for: {}",
-            pid, app_name
+            "Failed to get application by PID and child PID, trying by name: {}",
+            app_name
         );
-        Err(AutomationError::ElementNotFound(format!(
-            "Could not find window for process '{}' (PID: {}) or its children",
-            app_name, pid
-        )))
+        let app = engine.get_application_by_name(app_name)?;
+        app.activate_window()?;
+        Ok(app)
     }
 }
 

--- a/terminator/src/tests/get_applications_tests.rs
+++ b/terminator/src/tests/get_applications_tests.rs
@@ -1,0 +1,50 @@
+// this test is not compelte
+use crate::{AutomationError, Desktop};
+use tracing::Level;
+
+#[tokio::test]
+async fn get_applications_test() -> Result<(), AutomationError> {
+    tracing_subscriber::fmt::Subscriber::builder()
+        .with_max_level(Level::INFO)
+        .init();
+
+    let desktop = Desktop::new(false, false)?;
+
+    let applications = vec![
+        "notepad",
+        "firefox private",
+        "edge",
+        "paint",
+    ];
+
+    for app in applications {
+        let opened_app = desktop.open_application(app)?;
+        std::thread::sleep(std::time::Duration::from_secs(5));
+    }
+
+    let apps = desktop.applications()?;
+    tracing::info!("total apps: {:?}", apps.len());
+
+    for app in &apps {
+        tracing::info!("App Name: {:?}", app.name_or_empty());
+        let process_id = app.process_id().unwrap();
+        let output = std::process::Command::new("powershell")
+            .arg("-Command")
+            .arg(format!(
+                "Get-WmiObject Win32_Process | Where-Object {{ $_.ProcessId -eq {} }} | ForEach-Object {{ taskkill.exe /T /F /PID $_.ProcessId; Write-Output \"Process with PID $($_.ProcessId) has been terminated.\" }}",
+                process_id
+            ))
+            .output()
+            .unwrap();
+
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            println!("Command Output:\n{}", stdout);
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            eprintln!("Command Error:\n{}", stderr);
+        }
+    }
+
+    Ok(())
+}

--- a/terminator/src/tests/mod.rs
+++ b/terminator/src/tests/mod.rs
@@ -5,6 +5,7 @@ mod high_level_inputs_tests;
 mod performance_tests;
 mod selector_tests;
 mod test_serialization;
+mod get_applications_tests;
 
 // Initialize tracing for tests
 pub fn init_tracing() {


### PR DESCRIPTION
related: #21
some apps doesn't renders `Window` control type, some of them are using `Pane`, 

as an example claude and the discord app:

![image](https://github.com/user-attachments/assets/5025925b-4c54-4e77-8fbe-00800b34d5fa)

