### PR TITLE
Fix non-exhaustive pattern matching

### DIFF
--- a/terminator/src/platforms/linux.rs
+++ b/terminator/src/platforms/linux.rs
@@ -766,6 +766,9 @@ fn find_elements_inner<'a>(
             Selector::Role { .. } | Selector::Name(_) => {
                 // Supported - continue to processing below
             }
+            Selector::Invalid(reason) => {
+                return Err(AutomationError::InvalidArgument(reason.clone()));
+            }
         }
         // Only Role and Name selectors are supported below
         let root_binding = linux_engine.get_root_element();

--- a/terminator/src/platforms/macos.rs
+++ b/terminator/src/platforms/macos.rs
@@ -2851,6 +2851,7 @@ impl AccessibilityEngine for MacOSEngine {
             Selector::Position(_, _) => Err(AutomationError::UnsupportedOperation(
                 "Position selector not yet supported for macOS".to_string(),
             )),
+            Selector::Invalid(reason) => Err(AutomationError::InvalidArgument(reason.clone())),
         }
     }
 
@@ -3136,6 +3137,7 @@ impl AccessibilityEngine for MacOSEngine {
             Selector::Position(_, _) => Err(AutomationError::UnsupportedOperation(
                 "Position selector not yet supported for macOS".to_string(),
             )),
+            Selector::Invalid(reason) => Err(AutomationError::InvalidArgument(reason.clone())),
         }
     }
 

--- a/terminator/src/platforms/windows.rs
+++ b/terminator/src/platforms/windows.rs
@@ -1285,9 +1285,7 @@ impl AccessibilityEngine for WindowsEngine {
                 })?;
                 Ok(convert_uiautomation_element_to_terminator(element))
             }
-            Selector::Invalid(reason) => {
-                Err(AutomationError::InvalidSelector(reason.clone()))
-            }
+            Selector::Invalid(reason) => Err(AutomationError::InvalidSelector(reason.clone())),
         }
     }
 


### PR DESCRIPTION
```
## Pull Request Template

### Description
Resolves `non-exhaustive patterns` compilation errors by adding `Selector::Invalid` match arms to macOS and Linux platform implementations. This ensures all `Selector` enum variants are handled, returning `AutomationError::InvalidArgument` for invalid selectors.

### Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

### Video Demo (Recommended)
🎥 **Please include a video demo** showing your changes in action! We might use it to post on social media and grow the community.

**Suggested editing tools:**
- [Cap.so](https://cap.so/)
- [Screen.studio](https://screen.studio/)
- [CapCut](https://www.capcut.com/)
- [Kapwing](https://www.kapwing.com/)
- [Descript](https://www.descript.com/)


### AI Review & Code Quality
- [x] I asked AI to critique my PR and incorporated feedback
- [x] I formatted my code properly
- [x] I tested my changes locally

### Checklist
- [x] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [ ] Updated documentation if needed

### Additional Notes
- For macOS (`terminator/src/platforms/macos.rs`), `find_elements` and `find_element` now handle `Selector::Invalid` by returning `AutomationError::InvalidArgument`.
- For Linux (`terminator/src/platforms/linux.rs`), `find_elements_inner` handles `Selector::Invalid` by returning `AutomationError::InvalidArgument`.
- Includes a minor formatting fix in `terminator/src/platforms/windows.rs`.
```