### PR TITLE
Fix macos and linux build errors

### DIFF
--- a/terminator/src/platforms/linux.rs
+++ b/terminator/src/platforms/linux.rs
@@ -769,6 +769,15 @@ fn find_elements_inner<'a>(
             Selector::Invalid(reason) => {
                 return Err(AutomationError::InvalidArgument(reason.clone()));
             }
+            Selector::RightOf(_)
+            | Selector::LeftOf(_)
+            | Selector::Above(_)
+            | Selector::Below(_)
+            | Selector::Near(_) => {
+                return Err(AutomationError::UnsupportedPlatform(
+                    "Relative selectors (RightOf/LeftOf/Above/Below/Near) are not implemented for Linux".to_string(),
+                ));
+            }
         }
         // Only Role and Name selectors are supported below
         let root_binding = linux_engine.get_root_element();

--- a/terminator/src/platforms/macos.rs
+++ b/terminator/src/platforms/macos.rs
@@ -2852,6 +2852,9 @@ impl AccessibilityEngine for MacOSEngine {
                 "Position selector not yet supported for macOS".to_string(),
             )),
             Selector::Invalid(reason) => Err(AutomationError::InvalidArgument(reason.clone())),
+            Selector::RightOf(_) | Selector::LeftOf(_) | Selector::Above(_) | Selector::Below(_) | Selector::Near(_) => Err(AutomationError::UnsupportedOperation(
+                "Relative selectors (RightOf/LeftOf/Above/Below/Near) are not yet supported for macOS".to_string(),
+            )),
         }
     }
 
@@ -3138,6 +3141,9 @@ impl AccessibilityEngine for MacOSEngine {
                 "Position selector not yet supported for macOS".to_string(),
             )),
             Selector::Invalid(reason) => Err(AutomationError::InvalidArgument(reason.clone())),
+            Selector::RightOf(_) | Selector::LeftOf(_) | Selector::Above(_) | Selector::Below(_) | Selector::Near(_) => Err(AutomationError::UnsupportedOperation(
+                "Relative selectors (RightOf/LeftOf/Above/Below/Near) are not yet supported for macOS".to_string(),
+            )),
         }
     }
 


### PR DESCRIPTION
```
## Pull Request Template

### Description
This PR resolves the `non-exhaustive patterns` compiler errors on both macOS and Linux platforms. It adds explicit match arms for the new `RightOf`, `LeftOf`, `Above`, `Below`, and `Near` `Selector` variants in the respective platform implementations. These new relative selectors are currently not supported and will now return an `UnsupportedOperation` (macOS) or `UnsupportedPlatform` (Linux) error, making the pattern matching exhaustive and allowing the builds to pass.

### Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

### Video Demo (Recommended)
🎥 **Please include a video demo** showing your changes in action! We might use it to post on social media and grow the community.

**Suggested editing tools:**
- [Cap.so](https://cap.so/)
- [Screen.studio](https://screen.studio/)
- [CapCut](https://www.capcut.com/)
- [Kapwing](https://www.kapwing.com/)
- [Descript](https://www.descript.com/)


### AI Review & Code Quality
- [x] I asked AI to critique my PR and incorporated feedback
- [x] I formatted my code properly
- [x] I tested my changes locally

### Checklist
- [x] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [ ] Updated documentation if needed

### Additional Notes
The remaining Linux build failure related to `libspa` is an upstream dependency issue and not addressed in this PR.
```