### PR TITLE
Implement set_value tool in MCP hat

### DIFF
--- a/terminator-mcp-agent/src/utils.rs
+++ b/terminator-mcp-agent/src/utils.rs
@@ -310,7 +310,9 @@ pub struct SelectOptionArgs {
     pub option_name: String,
     #[schemars(description = "Optional alternative selectors.")]
     pub alternative_selectors: Option<String>,
-    #[schemars(description = "Optional fallback selectors to try sequentially if the primary selector fails.  These selectors are **only** attempted after the primary selector (and any parallel alternatives) time-out.  List can be comma-separated.")]
+    #[schemars(
+        description = "Optional fallback selectors to try sequentially if the primary selector fails.  These selectors are **only** attempted after the primary selector (and any parallel alternatives) time-out.  List can be comma-separated."
+    )]
     pub fallback_selectors: Option<String>,
     #[schemars(description = "Optional timeout in milliseconds.")]
     pub timeout_ms: Option<u64>,
@@ -327,7 +329,9 @@ pub struct SetToggledArgs {
     pub state: bool,
     #[schemars(description = "Optional alternative selectors.")]
     pub alternative_selectors: Option<String>,
-    #[schemars(description = "Optional fallback selectors to try sequentially if the primary selector fails.  These selectors are **only** attempted after the primary selector (and any parallel alternatives) time-out.  List can be comma-separated.")]
+    #[schemars(
+        description = "Optional fallback selectors to try sequentially if the primary selector fails.  These selectors are **only** attempted after the primary selector (and any parallel alternatives) time-out.  List can be comma-separated."
+    )]
     pub fallback_selectors: Option<String>,
     #[schemars(description = "Optional timeout in milliseconds.")]
     pub timeout_ms: Option<u64>,
@@ -370,7 +374,28 @@ pub struct SetRangeValueArgs {
     pub value: f64,
     #[schemars(description = "Optional alternative selectors.")]
     pub alternative_selectors: Option<String>,
-    #[schemars(description = "Optional fallback selectors to try sequentially if the primary selector fails.  These selectors are **only** attempted after the primary selector (and any parallel alternatives) time-out.  List can be comma-separated.")]
+    #[schemars(
+        description = "Optional fallback selectors to try sequentially if the primary selector fails.  These selectors are **only** attempted after the primary selector (and any parallel alternatives) time-out.  List can be comma-separated."
+    )]
+    pub fallback_selectors: Option<String>,
+    #[schemars(description = "Optional timeout in milliseconds.")]
+    pub timeout_ms: Option<u64>,
+    #[schemars(description = "Whether to include full UI tree in the response.")]
+    pub include_tree: Option<bool>,
+    pub retries: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct SetValueArgs {
+    #[schemars(description = "A string selector to locate the element whose value will be set.")]
+    pub selector: String,
+    #[schemars(description = "The text value to set.")]
+    pub value: String,
+    #[schemars(description = "Optional alternative selectors.")]
+    pub alternative_selectors: Option<String>,
+    #[schemars(
+        description = "Optional fallback selectors to try sequentially if the primary selector fails.  These selectors are **only** attempted after the primary selector (and any parallel alternatives) time-out.  List can be comma-separated."
+    )]
     pub fallback_selectors: Option<String>,
     #[schemars(description = "Optional timeout in milliseconds.")]
     pub timeout_ms: Option<u64>,
@@ -387,7 +412,9 @@ pub struct SetSelectedArgs {
     pub state: bool,
     #[schemars(description = "Optional alternative selectors.")]
     pub alternative_selectors: Option<String>,
-    #[schemars(description = "Optional fallback selectors to try sequentially if the primary selector fails.  These selectors are **only** attempted after the primary selector (and any parallel alternatives) time-out.  List can be comma-separated.")]
+    #[schemars(
+        description = "Optional fallback selectors to try sequentially if the primary selector fails.  These selectors are **only** attempted after the primary selector (and any parallel alternatives) time-out.  List can be comma-separated."
+    )]
     pub fallback_selectors: Option<String>,
     #[schemars(description = "Optional timeout in milliseconds.")]
     pub timeout_ms: Option<u64>,
@@ -830,7 +857,8 @@ where
     let mut last_error: Option<anyhow::Error> = None;
 
     for attempt in 0..=retry_count {
-        match find_element_with_fallbacks(desktop, primary_selector, alternatives, None, timeout_ms).await
+        match find_element_with_fallbacks(desktop, primary_selector, alternatives, None, timeout_ms)
+            .await
         {
             Ok((element, successful_selector)) => match action(element.clone()).await {
                 Ok(result) => return Ok(((result, element), successful_selector)),


### PR DESCRIPTION
## Pull Request Template

### Description
Adds a new `set_value` tool to the MCP agent, enabling direct modification of an element's text value using the underlying accessibility API. This provides a more robust and faster alternative to simulated typing for input fields.

### Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

### Video Demo (Recommended)
🎥 **Please include a video demo** showing your changes in action! We might use it to post on social media and grow the community.

**Suggested editing tools:**
- [Cap.so](https://cap.so/)
- [Screen.studio](https://screen.studio/)
- [CapCut](https://www.capcut.com/)
- [Kapwing](https://www.kapwing.com/)
- [Descript](https://www.descript.com/)


### AI Review & Code Quality
- [ ] I asked AI to critique my PR and incorporated feedback
- [ ] I formatted my code properly
- [ ] I tested my changes locally

### Checklist
- [ ] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [ ] Updated documentation if needed

### Additional Notes
This PR introduces the `set_value` tool, which allows setting the value of editable UI elements (like textboxes) directly.

*   A new `SetValueArgs` struct defines the tool's parameters, including `selector`, `value`, and standard retry/fallback options.
*   The `set_value` function in `server.rs` utilizes the existing robust element location logic (`find_and_execute_with_retry_with_fallback`) and then calls `element.set_value()` to update the element.
*   The tool returns detailed JSON output, including the element's information, the selector used, and the value that was set.