### PR TITLE
Implement nth element selector

### DIFF
--- a/bindings/nodejs/src/locator.rs
+++ b/bindings/nodejs/src/locator.rs
@@ -74,6 +74,19 @@ impl Locator {
             .map_err(map_error)
     }
 
+    /// (async) Get the nth matching element (0-based index).
+    ///
+    /// @param {number} index - Zero-based index of the element to retrieve.
+    /// @returns {Promise<Element>} The nth matching element.
+    #[napi]
+    pub async fn nth(&self, index: u32) -> napi::Result<Element> {
+        self.inner
+            .nth(index as usize, None)
+            .await
+            .map(Element::from)
+            .map_err(map_error)
+    }
+
     /// Set a default timeout for this locator.
     ///
     /// @param {number} timeoutMs - Timeout in milliseconds.

--- a/bindings/python/src/locator.rs
+++ b/bindings/python/src/locator.rs
@@ -85,6 +85,25 @@ impl Locator {
         })
     }
 
+    #[pyo3(name = "nth", text_signature = "($self, index)")]
+    /// (async) Get the nth matching element (0-based index).
+    ///
+    /// Args:
+    ///     index (int): Zero-based index of the element to retrieve.
+    ///
+    /// Returns:
+    ///     UIElement: The nth matching element.
+    pub fn nth<'py>(&self, py: Python<'py>, index: usize) -> PyResult<Bound<'py, PyAny>> {
+        let locator = self.inner.clone();
+        pyo3_tokio::future_into_py_with_locals(py, TaskLocals::with_running_loop(py)?, async move {
+            let element = locator
+                .nth(index, None)
+                .await
+                .map_err(automation_error_to_pyerr)?;
+            Ok(UIElement { inner: element })
+        })
+    }
+
     #[pyo3(name = "timeout", text_signature = "($self, timeout_ms)")]
     /// Set a default timeout for this locator.
     ///

--- a/terminator/src/locator.rs
+++ b/terminator/src/locator.rs
@@ -106,6 +106,25 @@ impl Locator {
         })
     }
 
+    pub async fn nth(
+        &self,
+        index: usize,
+        timeout: Option<Duration>,
+    ) -> Result<UIElement, AutomationError> {
+        // Fetch all matching elements within the given (or default) timeout
+        let elements = self.all(timeout, None).await?;
+
+        if let Some(element) = elements.get(index) {
+            Ok(element.clone())
+        } else {
+            Err(AutomationError::ElementNotFound(format!(
+                "Requested the {index}-th element but only {} element(s) matched selector {}",
+                elements.len(),
+                self.selector_string()
+            )))
+        }
+    }
+
     fn append_selector(&self, selector_to_append: Selector) -> Locator {
         let mut new_chain = match self.selector.clone() {
             Selector::Chain(existing_chain) => existing_chain,

--- a/terminator/src/selector.rs
+++ b/terminator/src/selector.rs
@@ -160,6 +160,13 @@ impl From<&str> for Selector {
             _ if s.starts_with('#') => Selector::Id(s[1..].to_string()),
             _ if s.starts_with('/') => Selector::Path(s.to_string()),
             _ if s.to_lowercase().starts_with("text:") => Selector::Text(s[5..].to_string()),
+            _ if s.to_lowercase().starts_with("nth:") || s.to_lowercase().starts_with("index:") => {
+                let value = s.splitn(2, ':').nth(1).unwrap_or("").trim();
+                match value.parse::<usize>() {
+                    Ok(idx) => Selector::Filter(idx),
+                    Err(_) => Selector::Invalid(format!("Invalid nth/index value: '{value}'")),
+                }
+            }
             _ => Selector::Invalid(format!(
                 "Unknown selector format: \"{s}\". Use prefixes like 'role:', 'name:', 'id:', 'text:', 'nativeid:', 'classname:', or 'pos:' to specify the selector type."
             )),


### PR DESCRIPTION
## Pull Request Template

### Description
This PR implements a Playwright-style `nth` method on `Locator` across Rust, Node.js, and Python bindings. This allows users to select the Nth matching UI element (0-based index) for a given selector, enhancing the ability to target specific elements, especially when combined with relative selectors (e.g., `rightof`, `below`).

### Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

### Video Demo (Recommended)
🎥 **Please include a video demo** showing your changes in action! We might use it to post on social media and grow the community.

**Suggested editing tools:**
- [Cap.so](https://cap.so/)
- [Screen.studio](https://screen.studio/)
- [CapCut](https://www.capcut.com/)
- [Kapwing](https://www.kapwing.com/)
- [Descript](https://www.descript.com/)


### AI Review & Code Quality
- [ ] I asked AI to critique my PR and incorporated feedback
- [ ] I formatted my code properly
- [ ] I tested my changes locally

### Checklist
- [ ] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [ ] Updated documentation if needed

### Additional Notes
Usage examples:

**Rust:**
```rust
let third_button = desktop
    .locator("role:button >> rightof:name:Submit")
    .nth(2, None)            // zero-based index
    .await?;
third_button.click()?;
```

**JS/TS:**
```ts
const third = await desktop.locator("role:button >> rightof:name=Submit").nth(2);
await third.click();
```

**Python:**
```python
third = await desktop.locator("role:button >> rightof:name:Submit").nth(2)
await third.click()
```