### PR TITLE
Install mcp server as windows service

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,37 @@ contributions are welcome! please feel free to submit issues and pull requests. 
 ## businesses 
 
 if you want desktop automation at scale for your business, [let's talk](https://mediar.ai)
+
+## 🪟 Windows: Install MCP Server as a Service
+
+Terminator ships a helper script that registers the MCP server (`mcp.exe`) as a native Windows service that
+
+* starts automatically on system boot
+* restarts itself if the process crashes or exits unexpectedly
+
+### 1. Copy `mcp.exe`
+Place your built (or downloaded) `mcp.exe` somewhere permanent, e.g.:
+```
+C:\Program Files\MCP\mcp.exe
+```
+
+### 2. Run the installer script (elevated PowerShell)
+```powershell
+cd <repo-root>\scripts
+# IMPORTANT: Launch a PowerShell **Run as Administrator** window first
+.\install-mcp-service.ps1 -ExecutablePath "C:\Program Files\MCP\mcp.exe"
+```
+Optional parameters:
+* `-Args` – command-line arguments passed to `mcp.exe` (default: `http`)
+* `-ServiceName`, `-DisplayName`, `-Description` – customise the service metadata
+
+### 3. Verify
+Open **Services** (Win+R → `services.msc`) and look for “MCP Server”. It should be **Running** and set to **Automatic**.
+
+### 4. Uninstalling
+```powershell
+Stop-Service MCPServer
+sc.exe delete MCPServer
+```
+
+---

--- a/scripts/install-mcp-service.ps1
+++ b/scripts/install-mcp-service.ps1
@@ -1,0 +1,53 @@
+<#
+  install-mcp-service.ps1
+  Installs the MCP server as a Windows service that auto-starts at boot
+  and restarts itself if it crashes.
+
+  Usage example (run from an elevated PowerShell session):
+  .\install-mcp-service.ps1 -ExecutablePath "C:\Program Files\MCP\mcp.exe"
+#>
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$ExecutablePath,                 # Full path to mcp.exe
+
+    [string]$Args        = "http",           # CLI args passed to mcp.exe
+    [string]$ServiceName = "MCPServer",      # Internal service name
+    [string]$DisplayName = "MCP Server",     # What shows up in Services MMC
+    [string]$Description = "MCP server running in HTTP mode"
+)
+
+# Helper: quote a path that may contain spaces
+function Quote($s) { return '"' + $s + '"' }
+
+# If the service already exists, remove it first (optional safety-belt)
+if (Get-Service -Name $ServiceName -ErrorAction SilentlyContinue) {
+    Write-Host "Service '$ServiceName' already exists – removing…" -ForegroundColor Yellow
+    Stop-Service  -Name $ServiceName -Force -ErrorAction SilentlyContinue
+    sc.exe delete $ServiceName | Out-Null
+    Start-Sleep 1
+}
+
+# Create the new service
+$binPath = "$(Quote $ExecutablePath) $Args"
+Write-Host "Creating service $ServiceName → $binPath"
+New-Service -Name         $ServiceName `
+            -BinaryPathName $binPath `
+            -DisplayName   $DisplayName `
+            -Description   $Description `
+            -StartupType   Automatic
+
+# Configure failure actions: restart after 5 s, up to 3 tries, never reset the counter
+sc.exe failure     $ServiceName reset= 0 actions= restart/5000/restart/5000/restart/5000 | Out-Null
+sc.exe failureflag $ServiceName 1                                                   | Out-Null
+
+# Start it up!
+Start-Service -Name $ServiceName
+Write-Host "Service '$ServiceName' installed and started successfully." -ForegroundColor Green
+
+<#
+Uninstalling later:
+
+Stop-Service MCPServer
+sc.exe delete MCPServer
+#>


### PR DESCRIPTION
```
## Pull Request Template

### Description
Adds a PowerShell script (`scripts/install-mcp-service.ps1`) to install the MCP server as a Windows service. This service is configured to automatically start at boot and restart if the process crashes. The `README.md` has been updated with detailed installation instructions.

### Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

### Video Demo (Recommended)
🎥 **Please include a video demo** showing your changes in action! We might use it to post on social media and grow the community.

**Suggested editing tools:**
- [Cap.so](https://cap.so/)
- [Screen.studio](https://screen.studio/)
- [CapCut](https://www.capcut.com/)
- [Kapwing](https://www.kapwing.com/)
- [Descript](https://www.descript.com/)


### AI Review & Code Quality
- [x] I asked AI to critique my PR and incorporated feedback
- [x] I formatted my code properly
- [x] I tested my changes locally

### Checklist
- [x] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [x] Updated documentation if needed

### Additional Notes
This change addresses the need for a robust, self-recovering deployment method for the MCP server on Windows, improving its reliability and ease of use for Windows-based systems.
```