### PR TITLE
Enable gist executor to read yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4405,6 +4405,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4697,6 +4710,7 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "terminator-rs",
  "terminator-workflow-recorder",
@@ -5270,6 +5284,12 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/terminator-mcp-agent/Cargo.toml
+++ b/terminator-mcp-agent/Cargo.toml
@@ -44,6 +44,8 @@ tempfile = "3"
 
 reqwest = { version = "0.12.5", features = ["json"] }
 
+# YAML parsing support
+serde_yaml = "0.9"
 
 
 [dev-dependencies]


### PR DESCRIPTION
## Pull Request Template

### Description
This PR enhances the `gist_executor` to support parsing workflow definitions from both JSON and YAML formats. It automatically detects and deserializes content, including direct `ExecuteSequenceArgs` and wrapped tool-call structures.

### Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

### Video Demo (Recommended)
🎥 **Please include a video demo** showing your changes in action! We might use it to post on social media and grow the community.

**Suggested editing tools:**
- [Cap.so](https://cap.so/)
- [Screen.studio](https://screen.studio/)
- [CapCut](https://www.capcut.com/)
- [Kapwing](https://www.kapwing.com/)
- [Descript](https://www.descript.com/)


### AI Review & Code Quality
- [ ] I asked AI to critique my PR and incorporated feedback
- [x] I formatted my code properly
- [x] I tested my changes locally

### Checklist
- [x] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [ ] Updated documentation if needed

### Additional Notes
The `gist_executor` now transparently handles workflows provided in either JSON or YAML (including wrapped tool-call formats); it automatically selects the correct parser without additional user flags. This improves flexibility for defining execution sequences.