### PR TITLE
Update variable substitution to github action style

### DIFF
--- a/terminator-mcp-agent/README.md
+++ b/terminator-mcp-agent/README.md
@@ -158,11 +158,11 @@ Now, when your MCP client runs `terminator-mcp-agent`, it will use your local bu
     "steps": [                // 4️⃣ Ordered actions & control flow
       {
         "tool_name": "open_application",
-        "arguments": { "path": "{{app_path}}" }
+        "arguments": { "path": "${{app_path}}" }
       },
       {
         "tool_name": "click_element", // 4a. Make sure the UI is reset
-        "arguments": { "selector": "{{selectors.btn_clear}}" },
+        "arguments": { "selector": "${{selectors.btn_clear}}" },
         "continue_on_error": true
       },
       {
@@ -171,15 +171,15 @@ Now, when your MCP client runs `terminator-mcp-agent`, it will use your local bu
           {
             "tool_name": "type_into_element",
             "arguments": {
-              "selector": "{{selectors.calc_window}}",
-              "text_to_type": "{{first_number}}"
+              "selector": "${{selectors.calc_window}}",
+              "text_to_type": "${{first_number}}"
             }
           }
         ]
       },
       {
         "tool_name": "click_element",
-        "arguments": { "selector": "{{selectors.btn_plus}}" }
+        "arguments": { "selector": "${{selectors.btn_plus}}" }
       },
       {
         "group_name": "Enter Second Number",
@@ -187,20 +187,20 @@ Now, when your MCP client runs `terminator-mcp-agent`, it will use your local bu
           {
             "tool_name": "type_into_element",
             "arguments": {
-              "selector": "{{selectors.calc_window}}",
-              "text_to_type": "{{second_number}}"
+              "selector": "${{selectors.calc_window}}",
+              "text_to_type": "${{second_number}}"
             }
           }
         ]
       },
       {
         "tool_name": "click_element",
-        "arguments": { "selector": "{{selectors.btn_equals}}" }
+        "arguments": { "selector": "${{selectors.btn_equals}}" }
       },
       {
         "tool_name": "wait_for_element",  // 4c. Capture final UI tree
         "arguments": {
-          "selector": "{{selectors.calc_window}}",
+          "selector": "${{selectors.calc_window}}",
           "condition": "exists",
           "include_tree": true,
           "timeout_ms": 2000
@@ -228,7 +228,7 @@ Now, when your MCP client runs `terminator-mcp-agent`, it will use your local bu
 
 1. **Variables vs. Inputs** – Declare once, override per-run. This is perfect for parameterizing CI pipelines or A/B test data.
 2. **Selectors** – Give every important UI element a *nickname*. It makes long workflows readable and easy to maintain.
-3. **Templating** – `{{ ... }}` lets you reference **any** key inside `variables`, `inputs`, or `selectors`. The engine uses Mustache-style rendering.
+3. **Templating** – `${{ ... }}` (GitHub Actions-style) *or* legacy `{{ ... }}` lets you reference **any** key inside `variables`, `inputs`, or `selectors`. Both syntaxes are supported; the engine uses Mustache-style rendering.
 4. **Groups & Control Flow** – Add `group_name`, `skippable`, `if`, or `continue_on_error` to any step for advanced branching.
 5. **Output Parsing** – Always end with a step that includes the UI tree, then use the declarative JSON DSL to mine the data you need.
 


### PR DESCRIPTION
```
## Pull Request Template

### Description
This PR introduces support for GitHub Actions-style variable syntax (`${{...}}`) in MCP workflows, alongside the existing `{{...}}` syntax for backward compatibility. This change aims to make variable substitution more intuitive for users familiar with GitHub Actions.

### Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [x] Documentation update
- [ ] Other:

### Video Demo (Recommended)
🎥 **Please include a video demo** showing your changes in action! We might use it to post on social media and grow the community.

**Suggested editing tools:**
- [Cap.so](https://cap.so/)
- [Screen.studio](https://screen.studio/)
- [CapCut](https://www.capcut.com/)
- [Kapwing](https://www.kapwing.com/)
- [Descript](https://www.descript.com/)


### AI Review & Code Quality
- [x] I asked AI to critique my PR and incorporated feedback
- [x] I formatted my code properly
- [x] I tested my changes locally

### Checklist
- [x] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [x] Updated documentation if needed

### Additional Notes
The `terminator-mcp-agent/README.md` has been updated to reflect the new syntax in examples and the templating section. New unit tests were added in `terminator-mcp-agent/src/helpers.rs` to cover the new `${{...}}` syntax. The original `{{...}}` syntax remains fully supported.
```