### PR TITLE
Expose tool output to other tools

### DIFF
--- a/terminator-mcp-agent/src/server.rs
+++ b/terminator-mcp-agent/src/server.rs
@@ -2458,6 +2458,18 @@ impl DesktopWrapper {
                 execution_context_map.insert("last_result".to_string(), last.clone());
             }
 
+            // Also make results accessible by step `id` similar to GitHub Actions syntax
+            if let Some(step_id) = original_step.id.as_ref() {
+                // Ensure a "steps" object exists in the context
+                let steps_entry = execution_context_map
+                    .entry("steps".to_string())
+                    .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+
+                if let serde_json::Value::Object(map) = steps_entry {
+                    map.insert(step_id.clone(), last.clone());
+                }
+            }
+
             // Decide next index based on success or fallback
             let step_succeeded = !step_error_occurred;
 


### PR DESCRIPTION
```
## Pull Request Template

### Description
This PR enhances the `execute_sequence` functionality to allow subsequent steps in a sequence to reference the outputs of previous tools. This is achieved by making the execution context mutable and updating it with each step's result.

### Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

### Video Demo (Recommended)
🎥 **Please include a video demo** showing your changes in action! We might use it to post on social media and grow the community.

**Suggested editing tools:**
- [Cap.so](https://cap.so/)
- [Screen.studio](https://screen.studio/)
- [CapCut](https://www.capcut.com/)
- [Kapwing](https://www.kapwing.com/)
- [Descript](https://www.descript.com/)


### AI Review & Code Quality
- [ ] I asked AI to critique my PR and incorporated feedback
- [ ] I formatted my code properly
- [ ] I tested my changes locally

### Checklist
- [ ] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [ ] Updated documentation if needed

### Additional Notes
The execution context now includes:
*   `last_result`: The output of the most recently executed step.
*   `results`: An array containing the outputs of all previously executed steps in the sequence.

This enables the use of placeholders such as `{{last_result.status}}` or `{{results.0.element.name}}` in subsequent tool arguments or conditions.
```