### PR TITLE
Integrate gist executor into terminator cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5106,6 +5106,7 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "tokio",
  "tracing",

--- a/terminator-cli/Cargo.toml
+++ b/terminator-cli/Cargo.toml
@@ -29,3 +29,4 @@ dotenvy = "0.15.7"
 reqwest = { version = "0.12.22", features = ["json", "rustls-tls"] }
 futures-util = "0.3.31"
 anthropic-sdk = "0.1.5"
+serde_yaml = "0.9"


### PR DESCRIPTION
## Pull Request Template

### Description
Introduces a new `terminator run` command to the CLI, enabling direct execution of YAML/JSON workflows. This allows users to run workflows defined in local files, GitHub Gists, or raw URLs, streamlining the workflow execution process within the `terminator` ecosystem.

### Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

### Video Demo (Recommended)
🎥 **Please include a video demo** showing your changes in action! We might use it to post on social media and grow the community.

**Suggested editing tools:**
- [Cap.so](https://cap.so/)
- [Screen.studio](https://screen.studio/)
- [CapCut](https://www.capcut.com/)
- [Kapwing](https://www.kapwing.com/)
- [Descript](https://www.descript.com/)


### AI Review & Code Quality
- [x] I asked AI to critique my PR and incorporated feedback
- [x] I formatted my code properly
- [x] I tested my changes locally

### Checklist
- [x] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [ ] Updated documentation if needed

### Additional Notes
- The direct `terminator-mcp-agent` dependency was removed from `terminator-cli`'s `Cargo.toml` to reduce compilation overhead. The CLI now defaults to spawning `npx -y terminator-mcp-agent` for MCP transport if no explicit `--url` or `--command` is provided.
- Workflows can be provided in both JSON and YAML formats.
- Supports `--dry-run` for validation and CLI overrides for `stop_on_error` and `include_detailed_results`.