### PR TITLE
Automate terminator cli release for cross-platform installation

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,43 @@
+<#
+Quick installer for Terminator CLI (Windows)
+Usage (latest): powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/mediar-ai/terminator/main/scripts/install.ps1 | iex"
+Usage (specific): powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/mediar-ai/terminator/main/scripts/install.ps1 | iex" -ArgumentList 'cli-v1.2.3'
+#>
+param(
+    [string]$Version = ""
+)
+
+$ErrorActionPreference = "Stop"
+$Repo = "mediar-ai/terminator"
+
+function Get-Latest {
+  (Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest").tag_name
+}
+
+if (-not $Version) {
+  $Version = Get-Latest
+}
+
+$arch = switch (([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture).ToString()) {
+  "Arm64" { "aarch64" }
+  "X64"  { "x86_64" }
+  Default { throw "Unsupported architecture" }
+}
+
+$archive = "terminator-windows-$arch.zip"
+$url = "https://github.com/$Repo/releases/download/$Version/$archive"
+$tempFile = Join-Path $env:TEMP $archive
+Write-Host "Downloading $url" -ForegroundColor Cyan
+Invoke-WebRequest -Uri $url -OutFile $tempFile -UseBasicParsing
+
+$tempDir = Join-Path $env:TEMP "terminator-cli"
+if (Test-Path $tempDir) { Remove-Item $tempDir -Recurse -Force }
+New-Item -ItemType Directory -Path $tempDir | Out-Null
+Expand-Archive -Path $tempFile -DestinationPath $tempDir -Force
+
+$binPath = Join-Path $tempDir "terminator.exe"
+$installDir = "$env:ProgramFiles"
+$destPath = Join-Path $installDir "terminator.exe"
+Move-Item -Path $binPath -Destination $destPath -Force
+
+Write-Host "✅ Terminator CLI installed at $destPath. Add it to your PATH if necessary." -ForegroundColor Green

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Quick installer for Terminator CLI
+# Usage (latest): curl -fsSL https://raw.githubusercontent.com/mediar-ai/terminator/main/scripts/install.sh | bash
+# Usage (specific): curl -fsSL https://raw.githubusercontent.com/mediar-ai/terminator/main/scripts/install.sh | bash -s -- cli-v1.2.3
+set -euo pipefail
+
+REPO="mediar-ai/terminator"
+VERSION="${1:-}"  # optional first arg is tag like cli-v1.2.3
+
+get_latest() {
+  curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | head -n1 | cut -d '"' -f4
+}
+
+if [[ -z "$VERSION" ]]; then
+  VERSION="$(get_latest)"
+fi
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+case "$OS" in
+  Linux) OS="linux" ;;
+  Darwin) OS="macos" ;;
+  *)
+    echo "Unsupported OS: $OS" >&2
+    exit 1
+    ;;
+esac
+
+case "$ARCH" in
+  x86_64|amd64) ARCH="x86_64" ;;
+  arm64|aarch64) ARCH="aarch64" ;;
+  *)
+    echo "Unsupported architecture: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+ARCHIVE="terminator-${OS}-${ARCH}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE}"
+echo "📦 Downloading $URL"
+curl -L "${URL}" | tar -xz
+
+chmod +x terminator*
+# Install to /usr/local/bin (may require sudo)
+sudo mv terminator /usr/local/bin/terminator
+
+echo "✅ Terminator CLI installed! Run 'terminator --help' to get started."


### PR DESCRIPTION
```
## Pull Request Template

### Description
Adds cross-platform installer scripts (`scripts/install.sh` and `scripts/install.ps1`) for the `terminator-cli`. These scripts enable users to install the CLI with a single command on Linux, macOS, and Windows, by fetching the appropriate binaries from GitHub Releases.

### Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

### Video Demo (Recommended)
🎥 **Please include a video demo** showing your changes in action! We might use it to post on social media and grow the community.

**Suggested editing tools:**
- [Cap.so](https://cap.so/)
- [Screen.studio](https://screen.studio/)
- [CapCut](https://www.capcut.com/)
- [Kapwing](https://www.kapwing.com/)
- [Descript](https://www.descript.com/)


### AI Review & Code Quality
- [ ] I asked AI to critique my PR and incorporated feedback
- [ ] I formatted my code properly
- [ ] I tested my changes locally

### Checklist
- [ ] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [ ] Updated documentation if needed

### Additional Notes
These scripts are designed to work in conjunction with the `release-cli.yml` GitHub Actions workflow, which builds and publishes the `terminator-cli` binaries to GitHub Releases with specific naming conventions.

**Installation One-Liners:**

**Linux / macOS:**
```bash
curl -fsSL https://raw.githubusercontent.com/mediar-ai/terminator/main/scripts/install.sh | bash
```

**Windows:**
```powershell
irm https://raw.githubusercontent.com/mediar-ai/terminator/main/scripts/install.ps1 | iex
```
