### PR TITLE
Expose properties to serialized ui tree

### DIFF
--- a/terminator/src/element.rs
+++ b/terminator/src/element.rs
@@ -198,6 +198,12 @@ pub struct UIElementAttributes {
     pub bounds: Option<(f64, f64, f64, f64)>, // Only populated for keyboard-focusable elements
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "is_false_bool")]
+    pub is_selected: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_count: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index_in_parent: Option<usize>,
 }
 
 impl fmt::Debug for UIElementAttributes {
@@ -267,6 +273,21 @@ impl fmt::Debug for UIElementAttributes {
         // Only show bounds if present
         if let Some(ref bounds) = self.bounds {
             debug_struct.field("bounds", bounds);
+        }
+
+        // Only show selected if true
+        if let Some(true) = self.is_selected {
+            debug_struct.field("is_selected", &true);
+        }
+
+        // Only show child_count if present
+        if let Some(count) = self.child_count {
+            debug_struct.field("child_count", &count);
+        }
+
+        // Only show index_in_parent if present
+        if let Some(index) = self.index_in_parent {
+            debug_struct.field("index_in_parent", &index);
         }
 
         debug_struct.finish()

--- a/terminator/src/element.rs
+++ b/terminator/src/element.rs
@@ -192,6 +192,8 @@ pub struct UIElementAttributes {
     pub is_keyboard_focusable: Option<bool>,
     #[serde(default, skip_serializing_if = "is_false_bool")]
     pub is_focused: Option<bool>,
+    #[serde(default, skip_serializing_if = "is_false_bool")]
+    pub is_toggled: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bounds: Option<(f64, f64, f64, f64)>, // Only populated for keyboard-focusable elements
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -255,6 +257,11 @@ impl fmt::Debug for UIElementAttributes {
         // Only show focused if true
         if let Some(true) = self.is_focused {
             debug_struct.field("is_focused", &true);
+        }
+
+        // Only show toggled if true
+        if let Some(true) = self.is_toggled {
+            debug_struct.field("is_toggled", &true);
         }
 
         // Only show bounds if present

--- a/terminator/src/platforms/linux.rs
+++ b/terminator/src/platforms/linux.rs
@@ -1928,6 +1928,7 @@ impl UIElementImpl for LinuxUIElement {
             is_focused: self.is_focused().ok(),
             enabled: self.is_enabled().ok(),
             bounds: self.bounds().ok(),
+            is_toggled: None,
             properties,
         }
     }

--- a/terminator/src/platforms/linux.rs
+++ b/terminator/src/platforms/linux.rs
@@ -1929,6 +1929,9 @@ impl UIElementImpl for LinuxUIElement {
             enabled: self.is_enabled().ok(),
             bounds: self.bounds().ok(),
             is_toggled: None,
+            is_selected: None,
+            child_count: None,
+            index_in_parent: None,
             properties,
         }
     }

--- a/terminator/src/platforms/macos.rs
+++ b/terminator/src/platforms/macos.rs
@@ -764,6 +764,7 @@ impl UIElementImpl for MacOSUIElement {
                 is_focused: self.is_focused().ok(),
                 enabled: self.is_enabled().ok(),
                 bounds: None, // Will be populated by get_configurable_attributes if focusable
+                is_toggled: None,
             };
 
             // Special handling for window title - try multiple attributes
@@ -869,6 +870,7 @@ impl UIElementImpl for MacOSUIElement {
             is_focused: self.is_focused().ok(),
             enabled: self.is_enabled().ok(),
             bounds: None, // Will be populated by get_configurable_attributes if focusable
+            is_toggled: None,
         };
 
         // Debug attribute collection

--- a/terminator/src/platforms/macos.rs
+++ b/terminator/src/platforms/macos.rs
@@ -765,6 +765,9 @@ impl UIElementImpl for MacOSUIElement {
                 enabled: self.is_enabled().ok(),
                 bounds: None, // Will be populated by get_configurable_attributes if focusable
                 is_toggled: None,
+                is_selected: None,
+                child_count: None,
+                index_in_parent: None,
             };
 
             // Special handling for window title - try multiple attributes
@@ -843,6 +846,22 @@ impl UIElementImpl for MacOSUIElement {
                 }
             }
 
+            // Populate AI layout fields
+            if let Ok(children) = self.children() {
+                attrs.child_count = Some(children.len());
+            }
+            if let Ok(Some(parent)) = self.parent() {
+                if let Ok(siblings) = parent.children() {
+                    let self_element = UIElement::new(self.clone_box());
+                    if let Some(idx) = siblings.iter().position(|e| e == &self_element) {
+                        attrs.index_in_parent = Some(idx);
+                    }
+                }
+            }
+            if let Ok(selected) = self.is_selected() {
+                attrs.is_selected = Some(selected);
+            }
+
             let duration = start.elapsed();
             debug!("Window attributes completed in {:?}", duration);
             if duration > std::time::Duration::from_millis(100) {
@@ -871,6 +890,9 @@ impl UIElementImpl for MacOSUIElement {
             enabled: self.is_enabled().ok(),
             bounds: None, // Will be populated by get_configurable_attributes if focusable
             is_toggled: None,
+            is_selected: None,
+            child_count: None,
+            index_in_parent: None,
         };
 
         // Debug attribute collection
@@ -985,6 +1007,22 @@ impl UIElementImpl for MacOSUIElement {
             }
         }
         debug!("Completed processing all {} attributes", attr_names.len());
+
+        // Populate AI layout fields
+        if let Ok(children) = self.children() {
+            attrs.child_count = Some(children.len());
+        }
+        if let Ok(Some(parent)) = self.parent() {
+            if let Ok(siblings) = parent.children() {
+                let self_element = UIElement::new(self.clone_box());
+                if let Some(idx) = siblings.iter().position(|e| e == &self_element) {
+                    attrs.index_in_parent = Some(idx);
+                }
+            }
+        }
+        if let Ok(selected) = self.is_selected() {
+            attrs.is_selected = Some(selected);
+        }
 
         let duration = start.elapsed();
         debug!(

--- a/terminator/src/platforms/windows.rs
+++ b/terminator/src/platforms/windows.rs
@@ -2758,6 +2758,9 @@ impl UIElementImpl for WindowsUIElement {
             text: None,
             enabled: None,
             is_toggled: None,
+            is_selected: None,
+            child_count: None,
+            index_in_parent: None,
         }
     }
 
@@ -5191,6 +5194,22 @@ fn get_configurable_attributes(
     // Add toggled state if available
     if let Ok(toggled) = element.is_toggled() {
         attrs.is_toggled = Some(toggled);
+    }
+
+    if let Ok(is_selected) = element.is_selected() {
+        attrs.is_selected = Some(is_selected);
+    }
+
+    if let Ok(children) = element.children() {
+        attrs.child_count = Some(children.len());
+        // index in parent
+        if let Ok(Some(parent)) = element.parent() {
+            if let Ok(siblings) = parent.children() {
+                if let Some(idx) = siblings.iter().position(|e| e == element) {
+                    attrs.index_in_parent = Some(idx);
+                }
+            }
+        }
     }
 
     attrs

--- a/terminator/src/platforms/windows.rs
+++ b/terminator/src/platforms/windows.rs
@@ -2757,6 +2757,7 @@ impl UIElementImpl for WindowsUIElement {
             bounds: None, // Will be populated by get_configurable_attributes if focusable
             text: None,
             enabled: None,
+            is_toggled: None,
         }
     }
 
@@ -5185,6 +5186,11 @@ fn get_configurable_attributes(
 
     if let Ok(is_enabled) = element.is_enabled() {
         attrs.enabled = Some(is_enabled);
+    }
+
+    // Add toggled state if available
+    if let Ok(toggled) = element.is_toggled() {
+        attrs.is_toggled = Some(toggled);
     }
 
     attrs


### PR DESCRIPTION
```
## Pull Request Template

### Description
Exposes the `is_toggled` property in the serialized UI tree, allowing clients to understand the toggle state of UI elements. This property is fully implemented and populated for Windows elements when available. For macOS and Linux, `is_toggled` is included in `UIElementAttributes` but defaults to `None`, ensuring cross-platform compatibility.

### Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

### Video Demo (Recommended)
🎥 **Please include a video demo** showing your changes in action! We might use it to post on social media and grow the community.

**Suggested editing tools:**
- [Cap.so](https://cap.so/)
- [Screen.studio](https://screen.studio/)
- [CapCut](https://www.capcut.com/)
- [Kapwing](https://www.kapwing.com/)
- [Descript](https://www.descript.com/)


### AI Review & Code Quality
- [x] I asked AI to critique my PR and incorporated feedback
- [x] I formatted my code properly
- [x] I tested my changes locally

### Checklist
- [x] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [ ] Updated documentation if needed

### Additional Notes
This change enhances the fidelity of the serialized UI tree by providing more detailed state information for interactive components.
```