### PR TITLE
Record user network protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,7 +977,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.8.8",
 ]
 
 [[package]]
@@ -1426,7 +1426,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading",
+ "libloading 0.8.8",
 ]
 
 [[package]]
@@ -1563,6 +1563,17 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
@@ -1572,10 +1583,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "etherparse"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "827292ea592108849932ad8e30218f8b1f21c0dfd0696698a18b5d0aed62d990"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "event-listener"
@@ -2764,6 +2794,16 @@ dependencies = [
 
 [[package]]
 name = "libloading"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
+name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
@@ -3073,7 +3113,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427802e8ec3a734331fec1035594a210ce1ff4dc5bc1950530920ab717964ea3"
 dependencies = [
- "libloading",
+ "libloading 0.8.8",
 ]
 
 [[package]]
@@ -3700,6 +3740,20 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pcap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da544c8115cc65b474554569c7654fc94a4f6a167f79192536e148fd654e17a"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno 0.2.8",
+ "libc",
+ "libloading 0.6.7",
+ "regex",
+ "windows-sys 0.36.1",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -4586,7 +4640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.9.1",
- "errno",
+ "errno 0.3.13",
  "libc",
  "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
@@ -4599,7 +4653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.1",
- "errno",
+ "errno 0.3.13",
  "libc",
  "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
@@ -5281,7 +5335,9 @@ dependencies = [
  "chrono",
  "criterion",
  "ctrlc",
+ "etherparse",
  "notify",
+ "pcap",
  "rand 0.8.5",
  "rdev",
  "serde",
@@ -6421,6 +6477,19 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6522,6 +6591,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -6537,6 +6612,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6570,6 +6651,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -6585,6 +6672,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6621,6 +6714,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/terminator-workflow-recorder/Cargo.toml
+++ b/terminator-workflow-recorder/Cargo.toml
@@ -32,6 +32,15 @@ rdev = "0.5.2"
 notify = "8.0"
 arboard = "3.0"
 
+# Optional network capture dependencies
+pcap = { version = "0.10", optional = true }
+etherparse = { version = "0.13", optional = true }
+
+[features]
+default = []
+# Enable passive network capture (requires libpcap on the target machine)
+network_capture = ["pcap", "etherparse"]
+
 [dev-dependencies]
 terminator = { workspace = true }
 tempfile = "3.0"

--- a/terminator-workflow-recorder/src/recorder/network.rs
+++ b/terminator-workflow-recorder/src/recorder/network.rs
@@ -1,0 +1,120 @@
+//! Network recorder implementation (optional)
+//! This module is only compiled when the "network_capture" cargo feature is enabled.
+//!
+//! For now we rely on the `pcap` crate to capture raw packets on the first non-loopback
+//! network interface. We emit very lightweight `NetworkEvent` objects that contain basic
+//! metadata about each captured packet (protocol, src/dst, ports and payload size).
+//!
+//! NOTE: Capturing network traffic usually requires elevated privileges on most
+//! operating systems. If the capture cannot be started due to insufficient
+//! permissions or missing libpcap installation, the recorder will gracefully
+//! fall back to a no-op implementation rather than crashing the workflow
+//! recorder. This way the rest of the recording pipeline continues to work.
+
+#[cfg(feature = "network_capture")]
+use {
+    crate::{events::NetworkEvent, EventMetadata, WorkflowEvent, WorkflowRecorderError},
+    pcap::{Capture, Device},
+    tokio::{sync::broadcast::Sender, task::JoinHandle},
+    tracing::{info, warn},
+};
+
+/// Recorder that passively captures network packets and pushes them to the shared broadcast
+/// channel so they become part of the workflow recording.
+#[cfg(feature = "network_capture")]
+pub struct NetworkRecorder {
+    handle: JoinHandle<()>,
+}
+
+#[cfg(feature = "network_capture")]
+impl NetworkRecorder {
+    /// Start capturing packets on the first available non-loopback interface.
+    pub async fn new(event_tx: Sender<WorkflowEvent>) -> Result<Self, WorkflowRecorderError> {
+        // Spawn the capture task on a blocking thread because libpcap is blocking
+        let handle = tokio::task::spawn_blocking(move || {
+            // Select the first active, non-loopback interface
+            let device = match Device::list().ok().and_then(|d| d.into_iter().find(|d| !d.flags.contains(pcap::DeviceFlags::LOOPBACK))) {
+                Some(dev) => dev,
+                None => {
+                    warn!("No suitable network device found for capture – network recording disabled");
+                    return;
+                }
+            };
+
+            info!("Starting network capture on {}", device.name);
+            let mut cap = match Capture::from_device(device).and_then(|c| c.promisc(true).immediate_mode(true).open()) {
+                Ok(c) => c,
+                Err(e) => {
+                    warn!("Failed to start network capture: {e}");
+                    return;
+                }
+            };
+
+            // Main capture loop
+            while let Ok(packet) = cap.next() {
+                // Very lightweight parsing – we only care about a few header fields
+                if let Some(net_event) = Self::build_event(&packet) {
+                    // Ignore errors if there are no active listeners
+                    let _ = event_tx.send(WorkflowEvent::Network(net_event));
+                }
+            }
+        });
+
+        Ok(Self { handle })
+    }
+
+    /// Stop capturing by aborting the underlying task.
+    pub async fn stop(self) -> Result<(), WorkflowRecorderError> {
+        self.handle.abort();
+        let _ = self.handle.await; // Drop any error
+        Ok(())
+    }
+
+    /// Very small helper to convert a `pcap::Packet` into our `NetworkEvent`.
+    fn build_event(packet: &pcap::Packet) -> Option<NetworkEvent> {
+        use etherparse::InternetSlice::Ipv4;
+        use etherparse::{SlicedPacket, TransportSlice};
+
+        // Parse headers with etherparse for convenience
+        let sliced = SlicedPacket::from_ethernet(&packet.data).ok()?;
+
+        let (src_ip, dest_ip) = match sliced.ip {
+            Some(Ipv4(header, _)) => (header.source_addr().to_string(), header.destination_addr().to_string()),
+            Some(etherparse::InternetSlice::Ipv6(header, _)) => (header.source_addr().to_string(), header.destination_addr().to_string()),
+            _ => return None,
+        };
+
+        let (protocol, src_port, dest_port) = match sliced.transport {
+            Some(TransportSlice::Tcp(tcp)) => ("TCP".to_string(), Some(tcp.source_port()), Some(tcp.destination_port())),
+            Some(TransportSlice::Udp(udp)) => ("UDP".to_string(), Some(udp.source_port()), Some(udp.destination_port())),
+            Some(TransportSlice::Icmpv4(_)) => ("ICMP".to_string(), None, None),
+            Some(TransportSlice::Icmpv6(_)) => ("ICMPv6".to_string(), None, None),
+            _ => ("OTHER".to_string(), None, None),
+        };
+
+        Some(NetworkEvent {
+            protocol,
+            src_ip,
+            src_port,
+            dest_ip,
+            dest_port,
+            packet_length: packet.header.len as usize,
+            metadata: EventMetadata::with_timestamp(),
+        })
+    }
+}
+
+/// Stub implementation compiled when the feature is NOT enabled – keeps API surface identical.
+#[cfg(not(feature = "network_capture"))]
+pub struct NetworkRecorder;
+
+#[cfg(not(feature = "network_capture"))]
+impl NetworkRecorder {
+    pub async fn new(_: tokio::sync::broadcast::Sender<crate::WorkflowEvent>) -> Result<Self, crate::WorkflowRecorderError> {
+        Ok(Self)
+    }
+
+    pub async fn stop(self) -> Result<(), crate::WorkflowRecorderError> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Pull Request Template

### Description
This PR introduces an **opt-in network protocol recording capability** to the Terminator Workflow Recorder. This is a foundational step towards enabling more robust, faster, and reliable automation by directly interacting with application network protocols, moving beyond fragile UI-based methods.

The feature captures basic packet metadata (protocol, source/destination IPs and ports, packet length) as `NetworkEvent`s. It is enabled via the `network_capture` Cargo feature and uses `pcap` for packet capture and `etherparse` for header parsing.

### Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

### Video Demo (Recommended)
🎥 This feature is primarily backend infrastructure and does not have a direct UI component for a video demo at this stage.

**Suggested editing tools:**
- [Cap.so](https://cap.so/)
- [Screen.studio](https://screen.studio/)
- [CapCut](https://www.capcut.com/)
- [Kapwing](https://www.kapwing.com/)
- [Descript](https://www.descript.com/)


### AI Review & Code Quality
- [x] I asked AI to critique my PR and incorporated feedback
- [x] I formatted my code properly
- [x] I tested my changes locally

### Checklist
- [x] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [ ] Updated documentation if needed

### Additional Notes
- To enable network recording, compile with the `network_capture` feature:
  `cargo build -p terminator-workflow-recorder --features network_capture`
- This feature requires `libpcap` to be installed on the target machine and may require elevated privileges to capture network traffic.
- This is an initial proof-of-concept for network-level automation, laying the groundwork for future enhancements like request filtering, replay, and mocking.