### PR TITLE
Log mcp agent actions for rollback

### DIFF
--- a/terminator-mcp-agent/Cargo.toml
+++ b/terminator-mcp-agent/Cargo.toml
@@ -21,6 +21,7 @@ tracing = { workspace = true }
 terminator = { workspace = true }
 serde_json = { workspace = true }
 tracing-subscriber = { workspace = true }
+tracing-appender = "0.2"
 rmcp = { version = "0.4.0", features = [
     "server",
     "client",

--- a/terminator-mcp-agent/README.md
+++ b/terminator-mcp-agent/README.md
@@ -376,6 +376,33 @@ For additional help, see the [Terminator CLI documentation](../terminator-cli/RE
 
 ---
 
+### Structured audit logging (JSONL)
+
+The agent emits structured JSON logs for every tool call. Logs are meant for human audit and future rollback tooling.
+
+- Location: `logs/mcp/mcp_audit.jsonl.YYYY-MM-DD` by default
+- Format: one JSON object per line
+- Rotation: daily (UTC)
+- Session correlation: every event includes a stable `session`
+
+Environment variables:
+
+- `MCP_LOG_DIR`: override log directory (default `logs/mcp`)
+- `MCP_LOG_FILE`: base filename (default `mcp_audit.jsonl`)
+- `MCP_SESSION_ID`: set a fixed session id (defaults to random UUID)
+- `MCP_JSON_LOG_DISABLE=1`: disable JSON audit logs entirely
+
+Example entries:
+
+```json
+{"timestamp":"2025-01-01T12:00:00Z","level":"INFO","fields":{"event":"tool_start","session":"7c2b...","tool":"click_element","full_tool":"mcp_terminator-mcp-agent_click_element","index":0,"step_id":"step-1","args":{"selector":"role:Button|name:Submit"}}}
+{"timestamp":"2025-01-01T12:00:00Z","level":"INFO","fields":{"event":"tool_end","session":"7c2b...","tool":"click_element","full_tool":"mcp_terminator-mcp-agent_click_element","index":0,"step_id":"step-1","status":"success","duration_ms":142,"content_count":1}}
+```
+
+Sensitive fields (e.g., `text_to_type`, `value`, `password`, `secret`, `token`, `script`, `run`) are redacted in logs.
+
+---
+
 ## 📚 Full `execute_sequence` Reference & Sample Workflow
 
 > **Why another example?** The quick start above shows the concept, but many users asked for a fully-annotated workflow schema. The example below automates the Windows **Calculator** app—so it is 100% safe to share and does **not** reveal any private customer data. Feel free to copy-paste and adapt it to your own application.


### PR DESCRIPTION
## Pull Request Template

### Description
Implements structured JSONL audit logging for MCP agent tool invocations and responses. This provides a human-readable record of agent actions, intended for future rollback mechanisms and general auditing.

### Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [x] Documentation update
- [ ] Other:

### Video Demo (Recommended)
🎥 **Please include a video demo** showing your changes in action! We might use it to post on social media and grow the community.

**Suggested editing tools:**
- [Cap.so](https://cap.so/)
- [Screen.studio](https://screen.studio/)
- [CapCut](https://www.capcut.com/)
- [Kapwing](https://www.kapwing.com/)
- [Descript](https://www.descript.com/)


### AI Review & Code Quality
- [x] I asked AI to critique my PR and incorporated feedback
- [x] I formatted my code properly
- [x] I tested my changes locally

### Checklist
- [x] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [x] Updated documentation if needed

### Additional Notes
This PR introduces:
*   **Structured Logging**: JSONL logs are written to `logs/mcp/mcp_audit.jsonl.YYYY-MM-DD` by default, with daily rotation.
*   **Tool Instrumentation**: `tool_start` and `tool_end` events are emitted for each tool execution, including `session` ID, `tool` name, `step_id`, `status`, `duration_ms`, and sanitized `args`.
*   **Argument Sanitization**: Sensitive fields (e.g., `text_to_type`, `password`, `secret`, `token`, `script`, `run`) are redacted, and long string values are truncated.
*   **Configuration**: Logging behavior can be controlled via environment variables: `MCP_LOG_DIR`, `MCP_LOG_FILE`, `MCP_SESSION_ID`, and `MCP_JSON_LOG_DISABLE=1`.
*   **Documentation**: The `README.md` has been updated with a dedicated section on structured audit logging, including configuration and example log entries.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc2d56cd-0214-4f60-93fd-8d0a628a87d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc2d56cd-0214-4f60-93fd-8d0a628a87d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

