### PR TITLE
Ensure tests close all opened applications and tabs

### DIFF
--- a/terminator/tests/click_timing_regression_test.rs
+++ b/terminator/tests/click_timing_regression_test.rs
@@ -1,4 +1,13 @@
 use std::{sync::Arc, time::Duration};
+use terminator::UIElement;
+
+// Ensures any opened UIElement (app/window) is closed when going out of scope
+struct CloseOnDrop<'a>(&'a UIElement);
+impl<'a> Drop for CloseOnDrop<'a> {
+    fn drop(&mut self) {
+        let _ = self.0.close();
+    }
+}
 
 fn start_test_server() -> (String, Arc<tiny_http::Server>) {
     let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
@@ -31,6 +40,7 @@ async fn test_click_hover_layout_shift_flaky() {
     let browser_window = desktop
         .open_url(&server_url, None)
         .expect("Failed to open test page");
+    let _guard = CloseOnDrop(&browser_window);
 
     // Find the target element (a div with role=button and name "Click Area")
     let target = browser_window

--- a/terminator/tests/open_url.rs
+++ b/terminator/tests/open_url.rs
@@ -1,5 +1,13 @@
 use terminator::Browser;
-use terminator::{platforms, AutomationError};
+use terminator::{platforms, AutomationError, UIElement};
+
+// Ensures any opened UIElement (app/window) is closed when going out of scope
+struct CloseOnDrop<'a>(&'a UIElement);
+impl<'a> Drop for CloseOnDrop<'a> {
+    fn drop(&mut self) {
+        let _ = self.0.close();
+    }
+}
 use tracing::{info, Level};
 
 #[tokio::test]
@@ -48,6 +56,7 @@ async fn test_open_url() -> Result<(), AutomationError> {
         } else {
             match result {
                 Ok(element) => {
+                    let _guard = CloseOnDrop(&element);
                     assert!(element.name().is_some(), "expected name for ui element");
                     info!(
                         "opened url '{:?}' in '{:?}' in '{:?}'",


### PR DESCRIPTION
## Pull Request Template

### Description
Ensures that tests reliably close any applications or browser tabs they open, even if the test fails or panics. This prevents resource leaks and improves test isolation by using RAII-style `CloseOnDrop` guards.

### Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

### Video Demo (Recommended)
🎥 Not applicable for this change, as it's an internal test infrastructure improvement.

### AI Review & Code Quality
- [x] I asked AI to critique my PR and incorporated feedback
- [x] I formatted my code properly
- [x] I tested my changes locally

### Checklist
- [x] Code follows project style guidelines
- [ ] Added video demo (Not applicable)
- [ ] Updated documentation if needed

### Additional Notes
Implemented `CloseOnDrop` in:
- `terminator/tests/click_timing_regression_test.rs`
- `terminator/tests/open_url.rs`
- `terminator/tests/open_url_unit_tests.rs`

This is the first batch of changes; further updates to workflow-recorder tests and `e2e_tests.rs` are planned.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4d6280f-033a-4463-afec-c2f546e6331b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f4d6280f-033a-4463-afec-c2f546e6331b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

