### PR TITLE
feat: Add dual PyPI publishing to CI/CD workflow

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -241,7 +241,7 @@ jobs:
         with:
           subject-path: 'bindings/python/wheels-*/*.whl'
 
-      - name: Publish to PyPI
+      - name: Publish to PyPI (terminator-py)
         uses: PyO3/maturin-action@v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
@@ -249,3 +249,55 @@ jobs:
           working-directory: bindings/python
           command: upload
           args: --non-interactive --skip-existing wheels-sdist/* wheels-windows-x64/* wheels-windows-arm64/* wheels-linux-x86_64/* wheels-macos-x86_64/* wheels-macos-arm64/*
+
+      - name: Checkout code for package rename
+        uses: actions/checkout@v4
+        with:
+          path: terminator-repo
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install wheel and twine
+        run: |
+          pip install wheel twine
+
+      - name: Copy and rename wheels for terminator package
+        run: |
+          mkdir -p terminator-wheels
+          # Copy all wheel files
+          find bindings/python/wheels-* -name "*.whl" -exec cp {} terminator-wheels/ \;
+          # Rename wheels from terminator_py to terminator
+          cd terminator-wheels
+          for wheel in *.whl; do
+            if [[ $wheel == *terminator_py* ]]; then
+              new_wheel=$(echo "$wheel" | sed 's/terminator_py/terminator/g')
+              mv "$wheel" "$new_wheel"
+            fi
+          done
+          cd ..
+          # Copy sdist and rename
+          cp bindings/python/wheels-sdist/*.tar.gz terminator-wheels/ || true
+          cd terminator-wheels
+          for sdist in *.tar.gz; do
+            if [[ $sdist == terminator-py* ]]; then
+              new_sdist=$(echo "$sdist" | sed 's/terminator-py/terminator/g')
+              mv "$sdist" "$new_sdist"
+            fi
+          done
+          cd ..
+
+      - name: Update metadata in wheels for terminator package
+        run: |
+          cd terminator-wheels
+          python ../terminator-repo/scripts/update_wheel_metadata.py
+          cd ..
+
+      - name: Publish to PyPI (terminator)
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TERMINATOR_PYPI_API_TOKEN }}
+        run: |
+          twine upload --non-interactive --skip-existing terminator-wheels/*

--- a/scripts/update_wheel_metadata.py
+++ b/scripts/update_wheel_metadata.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import os
+import sys
+import zipfile
+import tempfile
+import shutil
+from pathlib import Path
+
+def update_wheel_metadata(wheel_path):
+    """Update wheel metadata to change package name from terminator-py to terminator"""
+    temp_dir = tempfile.mkdtemp()
+    
+    try:
+        # Extract wheel
+        with zipfile.ZipFile(wheel_path, 'r') as zip_ref:
+            zip_ref.extractall(temp_dir)
+        
+        # Find and update METADATA file
+        for root, dirs, files in os.walk(temp_dir):
+            if 'METADATA' in files:
+                metadata_path = os.path.join(root, 'METADATA')
+                with open(metadata_path, 'r') as f:
+                    content = f.read()
+                
+                # Replace package name
+                content = content.replace('Name: terminator-py', 'Name: terminator')
+                content = content.replace('terminator-py', 'terminator')
+                
+                with open(metadata_path, 'w') as f:
+                    f.write(content)
+            
+            # Update dist-info directory name
+            if root.endswith('.dist-info') and 'terminator_py' in root:
+                new_root = root.replace('terminator_py', 'terminator')
+                os.rename(root, new_root)
+        
+        # Recreate wheel
+        new_wheel_path = wheel_path.replace('terminator_py', 'terminator')
+        with zipfile.ZipFile(new_wheel_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            for root, dirs, files in os.walk(temp_dir):
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    arcname = os.path.relpath(file_path, temp_dir)
+                    zipf.write(file_path, arcname)
+        
+        # Remove original wheel if different name
+        if new_wheel_path != wheel_path:
+            os.remove(wheel_path)
+        
+        print(f"Updated: {os.path.basename(wheel_path)} -> {os.path.basename(new_wheel_path)}")
+        
+    finally:
+        shutil.rmtree(temp_dir)
+
+def main():
+    # Process all wheels in current directory
+    for wheel_file in Path('.').glob('*.whl'):
+        if 'terminator_py' in str(wheel_file):
+            update_wheel_metadata(str(wheel_file))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Modified ci-wheels.yml to publish to both terminator-py and terminator packages
- Added script to update wheel metadata for the terminator package name
- The workflow now publishes to the original terminator-py package first
- Then renames and republishes to the newly acquired terminator package name

This allows us to maintain backward compatibility while also claiming the simpler package name on PyPI.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Pull Request Template

### Description
Brief description of changes in this PR.

### Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

### Video Demo (Recommended)
🎥 **Please include a video demo** showing your changes in action! We might use it to post on social media and grow the community.

**Suggested editing tools:**
- [Cap.so](https://cap.so/)
- [Screen.studio](https://screen.studio/)
- [CapCut](https://www.capcut.com/)
- [Kapwing](https://www.kapwing.com/)
- [Descript](https://www.descript.com/)


### AI Review & Code Quality
- [ ] I asked AI to critique my PR and incorporated feedback
- [ ] I formatted my code properly
- [ ] I tested my changes locally

### Checklist
- [ ] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [ ] Updated documentation if needed

### Additional Notes
Add any other context about the pull request here. 