### PR TITLE
Fix selectors cheat sheet table, add docs link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,19 +116,19 @@ While Terminator aims for full cross-platform support, current capabilities vary
 | Feature                      | Windows | macOS | Linux | Notes                                                |
 | ---------------------------- | :-----: | :---: | :---: | ---------------------------------------------------- |
 | **Core Automation**          |         |       |       |                                                      |
-| Element Locators             |   ✅    |  🟡   |  🟡   | Find elements by `name`, `role`, `window`, etc.      |
-| UI Actions (`click`, `type`) |   ✅    |  🟡   |  🟡   | Core interactions with UI elements.                  |
-| Application Management       |   ✅    |  🟡   |  🟡   | Launch, list, and manage applications.               |
-| Window Management            |   ✅    |  🟡   |  🟡   | Get active window, list windows.                     |
+| Element Locators             |    ✅    |   🟡   |   🟡   | Find elements by `name`, `role`, `window`, etc.      |
+| UI Actions (`click`, `type`) |    ✅    |   🟡   |   🟡   | Core interactions with UI elements.                  |
+| Application Management       |    ✅    |   🟡   |   🟡   | Launch, list, and manage applications.               |
+| Window Management            |    ✅    |   🟡   |   🟡   | Get active window, list windows.                     |
 | **Advanced Features**        |         |       |       |                                                      |
-| Workflow Recording           |   ✅    |  ❌   |  ❌   | Record human workflows for deterministic automation. |
-| Monitor Management           |   ✅    |  🟡   |  🟡   | Multi-display support.                               |
-| Screen & Element Capture     |   ✅    |  ✅   |  🟡   | Take screenshots of displays or elements.            |
+| Workflow Recording           |    ✅    |   ❌   |   ❌   | Record human workflows for deterministic automation. |
+| Monitor Management           |    ✅    |   🟡   |   🟡   | Multi-display support.                               |
+| Screen & Element Capture     |    ✅    |   ✅   |   🟡   | Take screenshots of displays or elements.            |
 | **Language Bindings**        |         |       |       |                                                      |
-| Python (`terminator.py`)     |   ✅    |  ✅   |  ✅   | `pip install terminator.py`                          |
-| TypeScript (`terminator.js`) |   ✅    |  ✅   |  ✅   | `npm i terminator.js`                                |
-| MCP (`terminator-mcp-agent`) |   ✅    |  ✅   |  ✅   | `npx -y terminator-mcp-agent --add-to-app [app]`     |
-| Rust (`terminator-rs`)       |   ✅    |  ✅   |  ✅   | `cargo add terminator-rs`                            |
+| Python (`terminator.py`)     |    ✅    |   ✅   |   ✅   | `pip install terminator.py`                          |
+| TypeScript (`terminator.js`) |    ✅    |   ✅   |   ✅   | `npm i terminator.js`                                |
+| MCP (`terminator-mcp-agent`) |    ✅    |   ✅   |   ✅   | `npx -y terminator-mcp-agent --add-to-app [app]`     |
+| Rust (`terminator-rs`)       |    ✅    |   ✅   |   ✅   | `cargo add terminator-rs`                            |
 
 **Legend:**
 
@@ -185,16 +185,17 @@ You can build and debug selector paths incrementally using `.locator()` chaining
 
 ## Explore Further
 
-- [https://github.com/mediar-ai/terminator/examples](https://github.com/mediar-ai/terminator/tree/main/examples)
+- **[Examples](https://github.com/mediar-ai/terminator/tree/main/examples)**
+- **[Documentation](https://github.com/mediar-ai/terminator/tree/main/docs)**
 
 ## Troubleshooting
 
 For detailed troubleshooting, debugging, and MCP server logs, see the [MCP Agent documentation](https://github.com/mediar-ai/terminator/tree/main/terminator-mcp-agent#troubleshooting--debugging).
 
-## contributing
+## Contributing
 
-contributions are welcome! please feel free to submit issues and pull requests. many parts are experimental, and help is appreciated. join our [discord](https://discord.gg/dU9EBuw7Uq) to discuss.
+Contributions are welcome! Please feel free to submit issues and pull requests. many parts are experimental, and help is appreciated. join our [Discord](https://discord.gg/dU9EBuw7Uq) to discuss.
 
-## businesses
+## Businesses
 
-if you want desktop automation at scale for your business, [let's talk](https://mediar.ai)
+If you want desktop automation at scale for your business, [let's talk](https://mediar.ai).

--- a/docs/SELECTORS_CHEATSHEET.md
+++ b/docs/SELECTORS_CHEATSHEET.md
@@ -2,26 +2,26 @@
 
 > Quick reference guide for building robust UI selectors in Terminator. Selectors follow the pattern `<prefix>:<value>` and can be chained with `>>` to walk the accessibility tree.
 
-| Prefix / Pattern     | Example                                          | What it matches                                                                  | Rough Playwright equivalent\*              |
-| -------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------ | --------------------------- |
-| `role:`              | `role:Button`                                    | Elements by accessibility **role** (e.g. `Button`, `Window`, `MenuItem`).        | `role=button`                              |
-| `name:`              | `name:Save`                                      | Element whose **accessible name/label** is "Save".                               | `text=Save` or `aria/Save`                 |
-| `id:`                | `id:submit`                                      | Accessibility **ID** (when exposed). On Windows this maps to `AutomationId`.     | `css=#submit`                              |
-| `nativeid:`          | `nativeid:42`                                    | **OS-specific automation id** (e.g. Windows `AutomationId`, macOS AXIdentifier). | n/a (desktop-specific)                     |
-| `classname:`         | `classname:Edit`                                 | UI **class name** (Win32 `ClassName`, Cocoa `AXRoleDescription`, etc.).          | `css=.Edit`                                |
-| `text:`              | `text:Open`                                      | Visible **text content** inside the element.                                     | `text=Open`                                |
-| `pos:x,y`            | `pos:100,200`                                    | Element located at **screen coordinates** `(x,y)` (last resort).                 | n/a                                        |
-| `visible:true/false` | `visible:true`                                   | Filter elements by **visibility** on screen.                                     | `:visible` pseudo-class                    |
-| `rightof:<sel>`      | `rightof:name:Username`                          | Element **right of** another selector.                                           | `right-of=` locators                       |
-| `leftof:<sel>`       | `leftof:role:Checkbox`                           | Element **left of** another selector.                                            | `left-of=` locators                        |
-| `above:<sel>`        | `above:name:OK`                                  | Element **above** another selector.                                              | `above=` locators                          |
-| `below:<sel>`        | `below:name:OK`                                  | Element **below** another selector.                                              | `below=` locators                          |
-| `near:<sel>`         | `near:text:Cancel`                               | Element **near** another selector (within tolerance).                            | `near=` locators                           |
-| `nth:<n>`            | `nth:0`                                          | Select the **nth element** (0-based) from matches.                               | `:nth-child(n)`                            |
-| `nth-<n>`            | `nth-1`                                          | Select the **nth element from end** (nth-1 = last, nth-2 = second-to-last).      | `:nth-last-child(n)`                       |
-| `..`                 | `..`                                             | Navigate to **parent element** (Playwright-style).                               | `xpath=..`                                 |
-| `role:<r>            | name:<n>`                                        | `role:Button                                                                     | name:Close`                                | **Compound** selector – role **and** name in one step. | `role=button[name="Close"]` |
-| `<selA> >> <selB>`   | `window:Calculator >> role:Button >> name:Seven` | **Chain** selectors to traverse hierarchy, similar to descendant combinators.    | `#Calculator >> role=button[name="Seven"]` |
+| Prefix / Pattern       | Example                                          | What it matches                                                                  | Rough Playwright equivalent\*              |
+| ---------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------- | ------------------------------------------ |
+| `role:`                | `role:Button`                                    | Elements by accessibility **role** (e.g. `Button`, `Window`, `MenuItem`).        | `role=button`                              |
+| `name:`                | `name:Save`                                      | Element whose **accessible name/label** is "Save".                               | `text=Save` or `aria/Save`                 |
+| `id:`                  | `id:submit`                                      | Accessibility **ID** (when exposed). On Windows this maps to `AutomationId`.     | `css=#submit`                              |
+| `nativeid:`            | `nativeid:42`                                    | **OS-specific automation id** (e.g. Windows `AutomationId`, macOS AXIdentifier). | n/a (desktop-specific)                     |
+| `classname:`           | `classname:Edit`                                 | UI **class name** (Win32 `ClassName`, Cocoa `AXRoleDescription`, etc.).          | `css=.Edit`                                |
+| `text:`                | `text:Open`                                      | Visible **text content** inside the element.                                     | `text=Open`                                |
+| `pos:x,y`              | `pos:100,200`                                    | Element located at **screen coordinates** `(x,y)` (last resort).                 | n/a                                        |
+| `visible:true/false`   | `visible:true`                                   | Filter elements by **visibility** on screen.                                     | `:visible` pseudo-class                    |
+| `rightof:<sel>`        | `rightof:name:Username`                          | Element **right of** another selector.                                           | `right-of=` locators                       |
+| `leftof:<sel>`         | `leftof:role:Checkbox`                           | Element **left of** another selector.                                            | `left-of=` locators                        |
+| `above:<sel>`          | `above:name:OK`                                  | Element **above** another selector.                                              | `above=` locators                          |
+| `below:<sel>`          | `below:name:OK`                                  | Element **below** another selector.                                              | `below=` locators                          |
+| `near:<sel>`           | `near:text:Cancel`                               | Element **near** another selector (within tolerance).                            | `near=` locators                           |
+| `nth:<n>`              | `nth:0`                                          | Select the **nth element** (0-based) from matches.                               | `:nth-child(n)`                            |
+| `nth-<n>`              | `nth-1`                                          | Select the **nth element from end** (nth-1 = last, nth-2 = second-to-last).      | `:nth-last-child(n)`                       |
+| `..`                   | `..`                                             | Navigate to **parent element** (Playwright-style).                               | `xpath=..`                                 |
+| `role:<r> \| name:<n>` | `role:Button \| name:Close`                      | **Compound** selector – role **and** name in one step.                           | `role=button[name="Close"]`                |
+| `<selA> >> <selB>`     | `window:Calculator >> role:Button >> name:Seven` | **Chain** selectors to traverse hierarchy, similar to descendant combinators.    | `#Calculator >> role=button[name="Seven"]` |
 
 \* The Playwright column shows an approximate conceptual mapping for web automation. Desktop and web runtimes expose different accessibility trees, so the exact selector semantics may differ.
 


### PR DESCRIPTION
### Description
Fixes Markdown bug in selectors cheat sheet table, and adds Documentation link to the Explore Further section of the README file, among other minor formatting improvements.

### Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [x] Documentation update
- [ ] Other:

### AI Review & Code Quality
- [ ] I asked AI to critique my PR and incorporated feedback
- [x] I formatted my code properly
- [x] I tested my changes locally

### Checklist
- [x] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [x] Updated documentation if needed