### PR TITLE
Fix error reporting for missing JavaScript files in MCP workflows

### DIFF
--- a/terminator-mcp-agent/src/server.rs
+++ b/terminator-mcp-agent/src/server.rs
@@ -1370,20 +1370,51 @@ impl DesktopWrapper {
                             }
                         }
 
-                        // Priority 3: Use as-is if still not found
+                        // Priority 3: Check current directory or use as-is
                         if resolved_path.is_none() {
                             let candidate = script_path.to_path_buf();
                             resolution_attempts.push(format!("as-is: {}", candidate.display()));
-                            tracing::info!(
-                                "[SCRIPTS_BASE_PATH] Using path as-is (not found in base paths): {}",
-                                script_file
-                            );
-                            resolved_path = Some(candidate);
+
+                            // Check if file exists before using it
+                            if candidate.exists() {
+                                tracing::info!(
+                                    "[SCRIPTS_BASE_PATH] Found script file at: {}",
+                                    candidate.display()
+                                );
+                                resolved_path = Some(candidate);
+                            } else {
+                                tracing::warn!(
+                                    "[SCRIPTS_BASE_PATH] Script file not found: {} (tried: {:?})",
+                                    script_file,
+                                    resolution_attempts
+                                );
+                                // Return error immediately for missing file
+                                return Err(McpError::invalid_params(
+                                    format!("Script file '{}' not found", script_file),
+                                    Some(json!({
+                                        "file": script_file,
+                                        "resolution_attempts": resolution_attempts,
+                                        "error": "File does not exist"
+                                    })),
+                                ));
+                            }
                         }
                     } else {
-                        // Absolute path - use as-is
-                        tracing::info!("[run_command] Using absolute path: {}", script_file);
-                        resolved_path = Some(script_path.to_path_buf());
+                        // Absolute path - check if exists
+                        let candidate = script_path.to_path_buf();
+                        if candidate.exists() {
+                            tracing::info!("[run_command] Using absolute path: {}", script_file);
+                            resolved_path = Some(candidate);
+                        } else {
+                            tracing::warn!("[run_command] Absolute script file not found: {}", script_file);
+                            return Err(McpError::invalid_params(
+                                format!("Script file '{}' not found", script_file),
+                                Some(json!({
+                                    "file": script_file,
+                                    "error": "File does not exist at absolute path"
+                                })),
+                            ));
+                        }
                     }
 
                     resolved_path.unwrap()
@@ -1850,20 +1881,51 @@ impl DesktopWrapper {
                         }
                     }
 
-                    // Priority 3: Use as-is if still not found
+                    // Priority 3: Check current directory or use as-is
                     if resolved_path.is_none() {
                         let candidate = script_path.to_path_buf();
                         resolution_attempts.push(format!("as-is: {}", candidate.display()));
-                        tracing::info!(
-                            "[run_command shell] Using path as-is (not found in base paths): {}",
-                            script_file
-                        );
-                        resolved_path = Some(candidate);
+
+                        // Check if file exists before using it
+                        if candidate.exists() {
+                            tracing::info!(
+                                "[run_command shell] Found script file at: {}",
+                                candidate.display()
+                            );
+                            resolved_path = Some(candidate);
+                        } else {
+                            tracing::warn!(
+                                "[run_command shell] Script file not found: {} (tried: {:?})",
+                                script_file,
+                                resolution_attempts
+                            );
+                            // Return error immediately for missing file
+                            return Err(McpError::invalid_params(
+                                format!("Script file '{}' not found", script_file),
+                                Some(json!({
+                                    "file": script_file,
+                                    "resolution_attempts": resolution_attempts,
+                                    "error": "File does not exist"
+                                })),
+                            ));
+                        }
                     }
                 } else {
-                    // Absolute path - use as-is
-                    tracing::info!("[run_command shell] Using absolute path: {}", script_file);
-                    resolved_path = Some(script_path.to_path_buf());
+                    // Absolute path - check if exists
+                    let candidate = script_path.to_path_buf();
+                    if candidate.exists() {
+                        tracing::info!("[run_command shell] Using absolute path: {}", script_file);
+                        resolved_path = Some(candidate);
+                    } else {
+                        tracing::warn!("[run_command shell] Absolute script file not found: {}", script_file);
+                        return Err(McpError::invalid_params(
+                            format!("Script file '{}' not found", script_file),
+                            Some(json!({
+                                "file": script_file,
+                                "error": "File does not exist at absolute path"
+                            })),
+                        ));
+                    }
                 }
 
                 resolved_path.unwrap()
@@ -3946,23 +4008,54 @@ Requires Chrome extension to be installed. See browser_dom_extraction.yml and de
                         }
                     }
 
-                    // Priority 3: Use as-is if still not found
+                    // Priority 3: Check current directory or use as-is
                     if resolved_path.is_none() {
                         let candidate = script_path.to_path_buf();
                         resolution_attempts.push(format!("as-is: {}", candidate.display()));
+
+                        // Check if file exists before using it
+                        if candidate.exists() {
+                            tracing::info!(
+                                "[execute_browser_script] Found script file at: {}",
+                                candidate.display()
+                            );
+                            resolved_path = Some(candidate);
+                        } else {
+                            tracing::warn!(
+                                "[execute_browser_script] Script file not found: {} (tried: {:?})",
+                                script_file,
+                                resolution_attempts
+                            );
+                            // Return error immediately for missing file
+                            return Err(McpError::invalid_params(
+                                format!("Script file '{}' not found", script_file),
+                                Some(json!({
+                                    "file": script_file,
+                                    "resolution_attempts": resolution_attempts,
+                                    "error": "File does not exist"
+                                })),
+                            ));
+                        }
+                    }
+                } else {
+                    // Absolute path - check if exists
+                    let candidate = script_path.to_path_buf();
+                    if candidate.exists() {
                         tracing::info!(
-                            "[execute_browser_script] Using path as-is (not found in base paths): {}",
+                            "[execute_browser_script] Using absolute path: {}",
                             script_file
                         );
                         resolved_path = Some(candidate);
+                    } else {
+                        tracing::warn!("[execute_browser_script] Absolute script file not found: {}", script_file);
+                        return Err(McpError::invalid_params(
+                            format!("Script file '{}' not found", script_file),
+                            Some(json!({
+                                "file": script_file,
+                                "error": "File does not exist at absolute path"
+                            })),
+                        ));
                     }
-                } else {
-                    // Absolute path - use as-is
-                    tracing::info!(
-                        "[execute_browser_script] Using absolute path: {}",
-                        script_file
-                    );
-                    resolved_path = Some(script_path.to_path_buf());
                 }
 
                 resolved_path.unwrap()


### PR DESCRIPTION
## Summary
- Fixes error reporting when script files referenced in YAML workflows don't exist
- Previously, the system would attempt to read non-existent files and could report false success
- Now provides clear error messages indicating which file wasn't found and what paths were tried

## Changes
- Added file existence checks before attempting to read script files in three locations:
  - `run_command` with JavaScript/TypeScript engine mode
  - `run_command` with shell mode
  - `execute_browser_script` tool
- Return descriptive error messages with file resolution attempts
- Properly propagate errors through the workflow execution system

## Test Results
Tested with a workflow that references a non-existent script file:
```yaml
name: Test Missing Script File Error
steps:
  - tool_name: run_command
    arguments:
      engine: javascript
      script_file: "non_existent_script.js"
```

The system now properly reports:
```
Script file not found: non_existent_script.js (tried: ["workflow_dir: ...", "as-is: ..."])
Tool 'run_command' at index 0 failed. Reason: -32602: Script file 'non_existent_script.js' not found
Status: partial_success with had_errors: true
```

## Impact
This fix ensures that workflows fail fast with clear error messages when required script files are missing, making debugging much easier for users.

🤖 Generated with [Claude Code](https://claude.ai/code)