### PR TITLE
fix: prevent telemetry from blocking CI smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ env:
   CARGO_NET_GIT_FETCH_WITH_CLI: true
   # Skip npm install in tests to avoid timeout
   TERMINATOR_SKIP_NPM_INSTALL: 1
+  # Skip telemetry collector check to avoid CI timeouts
+  OTEL_SKIP_COLLECTOR_CHECK: true
+  # Reduce retry time for telemetry in CI
+  OTEL_RETRY_DURATION_MINS: 0
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
Fixes CI smoke test failures caused by telemetry initialization blocking server startup.

## Problem
The telemetry retry logic (15-30 minutes) was blocking the MCP server from starting in CI environments where no OpenTelemetry collector is available. This caused health check timeouts and smoke test failures.

## Solution
Added environment variables to CI workflow:
- `OTEL_SKIP_COLLECTOR_CHECK=true` - Skip collector availability check
- `OTEL_RETRY_DURATION_MINS=0` - Disable retry attempts in CI

This allows the MCP agent to start immediately in CI without waiting for a collector.

## Test plan
- [x] CI smoke tests should pass after this change
- [x] Local development with collector still works (unaffected)
- [x] Telemetry remains optional and non-blocking

Fixes the issue reported where smoke tests were failing after telemetry changes.