### PR TITLE
fix: prevent telemetry tests from blocking in CI

### DIFF
--- a/terminator-mcp-agent/tests/telemetry_tests.rs
+++ b/terminator-mcp-agent/tests/telemetry_tests.rs
@@ -54,6 +54,9 @@ mod telemetry_tests {
     #[tokio::test]
     async fn test_telemetry_initialization() {
         // Disable SDK for testing to avoid network calls
+        // Skip collector check to avoid network calls and timeouts in CI
+        std::env::set_var("OTEL_SKIP_COLLECTOR_CHECK", "true");
+        std::env::set_var("OTEL_RETRY_DURATION_MINS", "0");
         std::env::set_var("OTEL_SDK_DISABLED", "true");
 
         // Test that init_telemetry doesn't panic
@@ -112,6 +115,9 @@ mod telemetry_tests {
 
         // Set environment to disable actual network calls during testing
         env::set_var("OTEL_SDK_DISABLED", "true");
+        // Skip collector check to avoid network calls and timeouts in CI
+        env::set_var("OTEL_SKIP_COLLECTOR_CHECK", "true");
+        env::set_var("OTEL_RETRY_DURATION_MINS", "0");
 
         let result = terminator_mcp_agent::telemetry::init_telemetry();
         assert!(result.is_ok());


### PR DESCRIPTION
## Summary
Fixes CI test failures caused by telemetry tests waiting for OpenTelemetry collector.

## Problem
The `test_telemetry_initialization` test was attempting to connect to an OpenTelemetry collector even though:
1. CI workflow had `OTEL_SKIP_COLLECTOR_CHECK=true` set at the top level
2. Tests spawn their own process context and don't inherit these env vars properly
3. This caused tests to wait up to 15 minutes for a collector that doesn't exist

## Solution
Added environment variables directly in the test functions:
- `OTEL_SKIP_COLLECTOR_CHECK=true` - Skip collector availability check
- `OTEL_RETRY_DURATION_MINS=0` - Disable retry attempts

This ensures tests don't block waiting for a non-existent collector.

## Changes
- Modified `test_telemetry_initialization()` to set skip env vars
- Modified `test_with_telemetry_enabled()` to set skip env vars

## Test plan
- [x] Local tests pass without blocking
- [ ] CI tests should pass after this change
- [x] Telemetry initialization still works when collector is available

Fixes the CI failures seen in recent builds where tests timeout waiting for collector.