### PR TITLE
feat: Add OTLP logs exporter + host.name segmentation for ClickHouse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,6 +1961,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hostname"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3458,6 +3469,18 @@ dependencies = [
  "pin-project-lite",
  "thiserror 1.0.69",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5feffc321035ad94088a7e5333abb4d84a8726e54a802e736ce9dd7237e85b"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5009,10 +5032,12 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
+ "hostname",
  "image",
  "libc",
  "ollama-rs",
  "opentelemetry",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",

--- a/terminator-mcp-agent/Cargo.toml
+++ b/terminator-mcp-agent/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [features]
 default = ["telemetry"]
-telemetry = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:opentelemetry-semantic-conventions"]
+telemetry = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:opentelemetry-semantic-conventions", "dep:opentelemetry-appender-tracing"]
 
 [lib]
 name = "terminator_mcp_agent"
@@ -48,6 +48,7 @@ uuid = { version = "1.10", features = ["v4", "serde"] }
 regex = { workspace = true }
 tempfile = "3"
 sysinfo = "0.33"
+hostname = "0.4"
 
 reqwest = { version = "0.12.5", features = ["json"] }
 
@@ -56,9 +57,10 @@ serde_yaml = "0.9"
 
 # OpenTelemetry dependencies (optional, behind 'telemetry' feature)
 opentelemetry = { version = "0.27", optional = true }
-opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"], optional = true }
-opentelemetry-otlp = { version = "0.27", features = ["http-proto", "reqwest-client"], optional = true }
+opentelemetry_sdk = { version = "0.27", features = ["rt-tokio", "logs"], optional = true }
+opentelemetry-otlp = { version = "0.27", features = ["http-proto", "reqwest-client", "logs"], optional = true }
 opentelemetry-semantic-conventions = { version = "0.27", optional = true }
+opentelemetry-appender-tracing = { version = "0.27", optional = true }
 
 # Dependencies for AI summarizer binary - TODO add behind feature flag
 ollama-rs = "0.3.2"


### PR DESCRIPTION
## Problem
Currently only **traces** are sent to ClickHouse, but **logs** (tracing::info!, error!, debug!) are not. This means we're missing critical debugging information in the observability dashboard.

Also, there's no way to segment telemetry by host/machine in ClickHouse queries.

## Solution
This PR adds:
1. **OTLP logs exporter** - All tracing logs now flow to ClickHouse via OTLP  
2. **host.name attribute** - Added to both traces and logs for segmentation

## Changes
- Add `opentelemetry-appender-tracing` (v0.27) and `hostname` (v0.4) dependencies
- Add `logs` feature to `opentelemetry_sdk` and `opentelemetry-otlp`
- Create `create_otel_logs_layer()` function that returns `OpenTelemetryTracingBridge`
- Modify `init_logging()` to optionally include OTLP layer during subscriber setup
- Add `host.name` resource attribute to both traces and logs
- OTLP layer is added **first** to work with `Registry` type (Rust tracing-subscriber quirk)

## Result
### Before
- ✅ Traces → OTLP → ClickHouse
- ❌ Logs → files/console only
- ❌ No host segmentation

### After  
- ✅ Traces → OTLP → ClickHouse (with `host.name`)
- ✅ Logs → OTLP → ClickHouse (with `host.name`)
- ✅ Can query by host: `SELECT * FROM otel_logs WHERE ResourceAttributes['host.name'] = 'mcp-vm-1'`

## Testing
```bash
# Build
cargo build --release -p terminator-mcp-agent

# Run with OTLP enabled
env OTEL_EXPORTER_OTLP_ENDPOINT="http://collector:4318" \
    ./target/release/terminator-mcp-agent -t http -p 8080

# All tracing::info!, error!, debug! calls will now be exported to OTLP
```

## Backward Compatibility
✅ Fully backward compatible - logs export only enabled if `OTEL_EXPORTER_OTLP_ENDPOINT` is set
✅ Works with existing telemetry configuration
✅ No breaking changes