### PR TITLE
fix(telemetry): apply RUST_LOG filter to OTLP logs layer

### DIFF
--- a/terminator-mcp-agent/src/utils.rs
+++ b/terminator-mcp-agent/src/utils.rs
@@ -1255,7 +1255,10 @@ pub fn init_logging() -> Result<Option<LogCapture>> {
             Some(otel_layer) => {
                 use tracing_subscriber::layer::SubscriberExt;
                 let subscriber = tracing_subscriber::registry()
-                    .with(otel_layer) // OTEL layer must be added first to work with Registry type
+                    .with(
+                        // OTEL layer with RUST_LOG filtering - CRITICAL to avoid HTTP client noise
+                        otel_layer.with_filter(EnvFilter::from_default_env().add_directive(log_level.into()))
+                    )
                     .with(
                         // Console/stderr layer
                         tracing_subscriber::fmt::layer()


### PR DESCRIPTION
## Problem

OTLP logs layer was capturing ALL debug logs including hyper/reqwest HTTP client internals, completely ignoring RUST_LOG environment variable filters.

This resulted in **95% of telemetry logs being HTTP connection pool noise** instead of actual application logs:
- `pooling idle connection for...`
- `take? ...`
- `put; add idle...`

In production, this made telemetry unusable - ClickHouse filled with 14,469 hyper logs vs only 733 actual MCP logs per hour.

## Root Cause

In `terminator-mcp-agent/src/utils.rs`, the OTLP layer was added without an EnvFilter:

```rust
// BROKEN - ignores RUST_LOG
.with(otel_layer)
```

Meanwhile, console and file layers correctly applied EnvFilter:

```rust
.with(
    tracing_subscriber::fmt::layer()
        .with_filter(EnvFilter::from_default_env().add_directive(log_level.into()))
)
```

## Solution

Apply the same EnvFilter to the OTLP layer:

```rust
.with(
    otel_layer.with_filter(EnvFilter::from_default_env().add_directive(log_level.into()))
)
```

## Impact

**Before:**
- 15,226 total logs/hour (95% HTTP noise)
- 733 actual application logs/hour (5%)
- Telemetry storage wasted on connection pool traces

**After:**
- Only actual application logs sent to OTLP
- Clean telemetry following RUST_LOG directives
- Reduced telemetry costs and improved signal-to-noise

## Testing

Tested with Azure VM deployment:

```bash
RUST_LOG=terminator_mcp_agent=debug,hyper=warn,reqwest=warn,h2=warn
```

Result: ✅ Only MCP logs in ClickHouse, no hyper/reqwest noise

## Example Usage

```bash
# Get MCP debug logs but silence HTTP client
RUST_LOG=terminator_mcp_agent=debug,hyper=warn,reqwest=warn

# All debug except HTTP clients
RUST_LOG=debug,hyper=warn,reqwest=warn,h2=warn

# Production: only info+ everywhere
RUST_LOG=info
```