### PR TITLE
Fix: Implement working client-side Bearer token authentication

### DIFF
--- a/terminator-cli/src/mcp_client.rs
+++ b/terminator-cli/src/mcp_client.rs
@@ -46,13 +46,18 @@ fn create_command(executable: &str, args: &[String]) -> Command {
 }
 
 /// Create HTTP transport with optional authentication
-/// Note: RMCP 0.6.3 has auth_header in config but it's not exported in public API
-/// For now, authentication must be handled at the server level or via custom HTTP client
-fn create_http_transport(url: &str, _auth_token: Option<&String>) -> StreamableHttpClientTransport<reqwest::Client> {
-    // TODO: Once RMCP exposes auth configuration in public API, add Bearer token here
-    // For now, the MCP server will need to allow requests without auth or we need to
-    // implement custom HTTP client with auth headers
-    StreamableHttpClientTransport::from_uri(url)
+fn create_http_transport(url: &str, auth_token: Option<&String>) -> StreamableHttpClientTransport<reqwest::Client> {
+    use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+
+    if let Some(token) = auth_token {
+        // Create config with authentication
+        let config = StreamableHttpClientTransportConfig::with_uri(url)
+            .auth_header(token);
+        StreamableHttpClientTransport::with_client(reqwest::Client::new(), config)
+    } else {
+        // No authentication
+        StreamableHttpClientTransport::from_uri(url)
+    }
 }
 
 /// Find executable with cross-platform path resolution


### PR DESCRIPTION
## Summary
- Fixes broken authentication in terminator-cli MCP client
- Uses RMCP's `StreamableHttpClientTransportConfig::auth_header()` method
- Client can now send Bearer tokens to authenticated MCP servers
- Updates documentation with working code examples

## Problem
After PR #313 was merged, the authentication system was **broken**:
- ✅ Server: Correctly validates Bearer tokens and rejects unauthorized requests (401)
- ❌ Client: Could NOT send Bearer tokens (was using wrong/non-existent API)
- ❗ Result: terminator-cli **cannot connect** to its own authenticated MCP server

The previous implementation had TODO comments saying RMCP doesn't expose auth config, but this was **incorrect** - it was always available via `rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig`.

## Solution
Uses the correct RMCP API:
```rust
let config = StreamableHttpClientTransportConfig::with_uri(url)
    .auth_header(token);
StreamableHttpClientTransport::with_client(reqwest::Client::new(), config)
```

## Testing
✅ Code compiles successfully
✅ Uses public RMCP API (no private imports)
✅ Follows RMCP's documented auth pattern

## Changes
- `terminator-cli/src/mcp_client.rs`: Implement working auth using StreamableHttpClientTransportConfig
- `docs/authentication.md`: Add code examples showing the correct implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)