### PR TITLE
feat: Add Sentry error tracking behind optional feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,6 +1291,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,7 +2110,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -3575,6 +3585,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_info"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0e1ac5fde8d43c34139135df8ea9ee9465394b2d8d20f032d38998f64afffc3"
+dependencies = [
+ "log",
+ "plist",
+ "serde",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3691,6 +3713,19 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.11.0",
+ "quick-xml 0.38.3",
+ "serde",
+ "time",
+]
 
 [[package]]
 name = "plotters"
@@ -4037,6 +4072,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.38.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4371,7 +4415,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -4459,6 +4503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4490,6 +4543,7 @@ version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4630,6 +4684,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sentry"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016958f51b96861dead7c1e02290f138411d05e94fad175c8636a835dee6e51e"
+dependencies = [
+ "httpdate",
+ "reqwest",
+ "rustls",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57712c24e99252ef175b4b06c485294f10ad6bc5b5e1567ff3803ee7a0b7d3f"
+dependencies = [
+ "backtrace",
+ "once_cell",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba8754ec3b9279e00aa6d64916f211d44202370a1699afde1db2c16cbada089"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8b6dcd4fbae1e3e22b447f32670360b27e31b62ab040f7fb04e0f80c04d92"
+dependencies = [
+ "once_cell",
+ "rand 0.8.5",
+ "sentry-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de296dae6f01e931b65071ee5fe28d66a27909857f744018f107ed15fd1f6b25"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "263f73c757ed7915d3e1e34625eae18cad498a95b4261603d4ce3f87b159a6f0"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a71ed3a389948a6a6d92b98e997a2723ca22f09660c5a7b7388ecd509a70a527"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -5046,6 +5197,8 @@ dependencies = [
  "regex",
  "reqwest",
  "rmcp",
+ "sentry",
+ "sentry-tracing",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -5729,6 +5882,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "uni-ocr"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5790,6 +5952,21 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -6127,6 +6304,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]

--- a/terminator-mcp-agent/Cargo.toml
+++ b/terminator-mcp-agent/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [features]
 default = ["telemetry"]
 telemetry = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:opentelemetry-semantic-conventions", "dep:opentelemetry-appender-tracing"]
+sentry = ["dep:sentry", "dep:sentry-tracing"]
 
 [lib]
 name = "terminator_mcp_agent"
@@ -60,6 +61,10 @@ opentelemetry_sdk = { version = "0.27", features = ["rt-tokio", "logs"], optiona
 opentelemetry-otlp = { version = "0.27", features = ["http-proto", "reqwest-client", "logs"], optional = true }
 opentelemetry-semantic-conventions = { version = "0.27", optional = true }
 opentelemetry-appender-tracing = { version = "0.27", optional = true }
+
+# Sentry dependencies (optional, behind 'sentry' feature)
+sentry = { version = "0.35", optional = true, default-features = false, features = ["backtrace", "contexts", "panic", "reqwest", "rustls"] }
+sentry-tracing = { version = "0.35", optional = true }
 
 # Dependencies for AI summarizer binary - TODO add behind feature flag
 ollama-rs = "0.3.2"

--- a/terminator-mcp-agent/src/lib.rs
+++ b/terminator-mcp-agent/src/lib.rs
@@ -6,6 +6,7 @@ pub mod mcp_types;
 pub mod output_parser;
 pub mod prompt;
 pub mod scripting_engine;
+pub mod sentry;
 pub mod server;
 pub mod server_sequence;
 pub mod telemetry;

--- a/terminator-mcp-agent/src/main.rs
+++ b/terminator-mcp-agent/src/main.rs
@@ -246,6 +246,9 @@ async fn main() -> Result<()> {
 
     let log_capture = init_logging()?;
 
+    // Initialize Sentry if sentry feature is enabled (before OpenTelemetry)
+    let _sentry_guard = terminator_mcp_agent::sentry::init_sentry();
+
     // Initialize OpenTelemetry if telemetry feature is enabled (after logging is set up)
     terminator_mcp_agent::telemetry::init_telemetry()?;
 
@@ -652,6 +655,9 @@ async fn main() -> Result<()> {
 
     // Shutdown telemetry before exiting
     terminator_mcp_agent::telemetry::shutdown_telemetry();
+
+    // Shutdown Sentry before exiting (flushes pending events)
+    terminator_mcp_agent::sentry::shutdown_sentry();
 
     Ok(())
 }

--- a/terminator-mcp-agent/src/sentry.rs
+++ b/terminator-mcp-agent/src/sentry.rs
@@ -1,0 +1,163 @@
+// Sentry error tracking support for MCP server
+// This module is only compiled when the 'sentry' feature is enabled
+
+#[cfg(feature = "sentry")]
+pub use with_sentry::*;
+
+#[cfg(not(feature = "sentry"))]
+pub use without_sentry::*;
+
+// Implementation with Sentry enabled
+#[cfg(feature = "sentry")]
+mod with_sentry {
+    use tracing::{error, info};
+
+    /// Initialize Sentry error tracking
+    /// Requires SENTRY_DSN environment variable to be set
+    /// Returns a guard that should be kept alive for the lifetime of the application
+    pub fn init_sentry() -> Option<sentry::ClientInitGuard> {
+        // Check if Sentry is explicitly disabled
+        if std::env::var("SENTRY_DISABLED")
+            .unwrap_or_default()
+            .eq_ignore_ascii_case("true")
+        {
+            info!("Sentry is disabled via SENTRY_DISABLED environment variable");
+            return None;
+        }
+
+        // Get DSN from environment
+        let dsn = match std::env::var("SENTRY_DSN") {
+            Ok(dsn) if !dsn.is_empty() => dsn,
+            _ => {
+                info!("Sentry DSN not configured (SENTRY_DSN env var not set). Error tracking disabled.");
+                return None;
+            }
+        };
+
+        info!("Initializing Sentry error tracking...");
+
+        // Get environment and release information
+        let environment = std::env::var("SENTRY_ENVIRONMENT")
+            .unwrap_or_else(|_| "production".to_string());
+
+        let release = std::env::var("SENTRY_RELEASE")
+            .unwrap_or_else(|_| {
+                format!("terminator-mcp-agent@{}", env!("CARGO_PKG_VERSION"))
+            });
+
+        // Get sample rate (default to 1.0 = 100% of errors)
+        let traces_sample_rate = std::env::var("SENTRY_TRACES_SAMPLE_RATE")
+            .ok()
+            .and_then(|s| s.parse::<f32>().ok())
+            .unwrap_or(1.0);
+
+        // Initialize Sentry with configuration
+        let guard = sentry::init((
+            dsn,
+            sentry::ClientOptions {
+                release: Some(release.into()),
+                environment: Some(environment.into()),
+                traces_sample_rate,
+                attach_stacktrace: true,
+                // Don't send default PII (can be enabled via SENTRY_SEND_DEFAULT_PII=true)
+                send_default_pii: std::env::var("SENTRY_SEND_DEFAULT_PII")
+                    .unwrap_or_default()
+                    .eq_ignore_ascii_case("true"),
+                ..Default::default()
+            },
+        ));
+
+        // Add server context
+        sentry::configure_scope(|scope| {
+            scope.set_tag("server", "terminator-mcp-agent");
+            scope.set_tag("version", env!("CARGO_PKG_VERSION"));
+
+            // Add hostname for context
+            if let Ok(hostname) = hostname::get() {
+                if let Some(hostname_str) = hostname.to_str() {
+                    scope.set_tag("hostname", hostname_str);
+                }
+            }
+
+            // Add platform info
+            scope.set_tag("platform", std::env::consts::OS);
+            scope.set_tag("arch", std::env::consts::ARCH);
+        });
+
+        info!(
+            "Sentry initialized successfully (environment: {}, release: {})",
+            std::env::var("SENTRY_ENVIRONMENT").unwrap_or_else(|_| "production".to_string()),
+            release
+        );
+
+        Some(guard)
+    }
+
+    /// Create a Sentry tracing layer that can be added to the tracing subscriber
+    /// Returns None if Sentry is not initialized
+    pub fn create_sentry_layer(
+    ) -> Option<impl tracing_subscriber::Layer<tracing_subscriber::Registry> + Send + Sync> {
+        // Check if Sentry is disabled
+        if std::env::var("SENTRY_DISABLED")
+            .unwrap_or_default()
+            .eq_ignore_ascii_case("true")
+        {
+            return None;
+        }
+
+        // Check if DSN is set
+        if std::env::var("SENTRY_DSN").ok()?.is_empty() {
+            return None;
+        }
+
+        // Return sentry-tracing layer
+        // This will automatically capture ERROR and WARN level logs
+        Some(sentry_tracing::layer())
+    }
+
+    /// Shutdown Sentry gracefully
+    /// This flushes any pending events
+    pub fn shutdown_sentry() {
+        info!("Shutting down Sentry...");
+        // Flush with a 2 second timeout
+        sentry::flush(std::time::Duration::from_secs(2));
+    }
+
+    /// Capture an error manually (useful for non-panic errors)
+    pub fn capture_error(error: &anyhow::Error) {
+        sentry::capture_error(error);
+    }
+
+    /// Add a breadcrumb (useful for tracking events leading to errors)
+    pub fn add_breadcrumb(message: String, category: String) {
+        sentry::add_breadcrumb(sentry::Breadcrumb {
+            message: Some(message),
+            category: Some(category),
+            level: sentry::Level::Info,
+            ..Default::default()
+        });
+    }
+}
+
+// Stub implementation when Sentry is disabled
+#[cfg(not(feature = "sentry"))]
+mod without_sentry {
+    use tracing::debug;
+
+    pub fn init_sentry() -> Option<()> {
+        debug!("Sentry disabled: init_sentry (no-op)");
+        None
+    }
+
+    pub fn shutdown_sentry() {
+        debug!("Sentry disabled: shutdown_sentry (no-op)");
+    }
+
+    pub fn capture_error(_error: &anyhow::Error) {
+        debug!("Sentry disabled: capture_error (no-op)");
+    }
+
+    pub fn add_breadcrumb(_message: String, _category: String) {
+        debug!("Sentry disabled: add_breadcrumb (no-op)");
+    }
+}


### PR DESCRIPTION
## Summary
Add Sentry integration to the MCP server behind an optional `sentry` feature flag. This follows the same pattern as the existing `telemetry` feature.

## Implementation Details
- Added `sentry` feature flag to Cargo.toml (not enabled by default)
- Created sentry.rs module with conditional compilation
- Sentry only initialized when:
  1. Feature flag `--features sentry` is enabled during build
  2. `SENTRY_DSN` environment variable is set at runtime
- No-op stubs provided when feature is disabled

## Configuration
Sentry can be configured via environment variables:
- `SENTRY_DSN` - **Required** to enable Sentry (DSN from sentry.io project)
- `SENTRY_DISABLED` - Set to "true" to explicitly disable even if DSN is set
- `SENTRY_ENVIRONMENT` - Environment name (default: "production")
- `SENTRY_RELEASE` - Release version (default: "terminator-mcp-agent@{version}")
- `SENTRY_TRACES_SAMPLE_RATE` - Sample rate 0.0-1.0 (default: 1.0)
- `SENTRY_SEND_DEFAULT_PII` - Set to "true" to send personally identifiable information

## Usage Example

### Building with Sentry support:
```bash
cargo build -p terminator-mcp-agent --features sentry
```

### Running with Sentry enabled:
```bash
export SENTRY_DSN="https://your-dsn@sentry.io/project"
export SENTRY_ENVIRONMENT="staging"
./terminator-mcp-agent
```

## Benefits
- Zero runtime overhead when feature is disabled (default)
- Automatic panic capturing
- Error tracking with context (hostname, platform, version)
- Graceful shutdown with event flushing
- Follows existing telemetry feature pattern for consistency

## Testing
- ✅ Builds successfully without sentry feature (default)
- ✅ Sentry dependencies only compiled when feature is enabled
- ✅ No-op stubs work correctly when feature is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)