### PR TITLE
CI: Use Node 20 on Windows ARM64 in publish-mcp to fix setup-node failure

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -47,7 +47,16 @@ jobs:
       - name: Install Linux dependencies
         if: matrix.settings.host == 'ubuntu-22.04'
         run: bash scripts/install_linux_deps.sh
-      - name: Setup node
+
+      - name: Setup node (Windows ARM64)
+        if: matrix.settings.host == 'windows-11-arm'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup node (default)
+        if: matrix.settings.host != 'windows-11-arm'
         uses: actions/setup-node@v4
         with:
           node-version: 18


### PR DESCRIPTION
### PR Description

This PR fixes the Windows ARM64 CI failure by using Node 20 only for the `windows-11-arm` job, while keeping Node 18 for all other matrix runners.  
The failure occurs because Node 18 isn’t available for the `win32` + `arm64` combination, as seen in the [Actions log](https://github.com/mediar-ai/terminator/actions/runs/18883750489/job/53893588916).  

To resolve this, the “Setup node” step has been split into two conditional steps: one using Node 20 for Windows ARM64 and another using Node 18 for the rest.  
This change aligns with the existing setup in `.github/workflows/publish-npm.yml`, where Windows ARM64 already uses Node 20 for consistency.
