### PR TITLE
chore(build): optimise release binary size and performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,13 @@ ctrlc = "3.4"
 
 
 regex = "1.10.5"
+
+[profile.release]
+# Enables full cross-crate optimisations, producing the smallest and fastest binary.
+lto = "fat"
+# Because we bundle some of these executables with npm packages, we
+# remove everything to make the binary as small as possible.
+strip = "symbols"
+
+# See https://github.com/openai/codex/issues/1411 for details.
+codegen-units = 1


### PR DESCRIPTION


**Description:**
This PR introduces a **release profile** in `Cargo.toml`, inspired by OpenAI Codex’s optimisation approach:

[Codex Issue #1411](https://github.com/openai/codex/issues/1411)
[Codex Cargo.toml reference](https://github.com/openai/codex/blob/main/codex-rs/Cargo.toml#L261-L268)

The configuration focuses on **maximising performance** and **minimising binary size**, which is especially useful for distributing the MCP server or publishing it as part of an npm package.

### Impact



* Consistent with optimisations used in production-grade Rust MCP servers (e.g. Codex).


* **Smaller and faster binaries across all targets:**

* **Improved runtime performance**, especially for frequently loaded MCP servers and CLI tools.



### Rationale

* **`lto = "fat"`** — Enables full cross-crate Link Time Optimisation for better runtime efficiency and smaller binaries.
* **`strip = "symbols"`** — Removes symbol/debug data, reducing the distributed binary size.
* **`codegen-units = 1`** — Forces LLVM to perform whole-program optimisation, improving performance and size at the cost of longer compile times.




