### PR TITLE
fix build on macOS

### DIFF
--- a/crates/terminator/src/platforms/macos.rs
+++ b/crates/terminator/src/platforms/macos.rs
@@ -3058,7 +3058,7 @@ impl AccessibilityEngine for MacOSEngine {
             (root.cloned(), selector.clone())
         };
 
-        let start_element = if let Some(el) = actual_root {
+        let start_element = if let Some(ref el) = actual_root {
             if let Some(macos_el) = el.as_any().downcast_ref::<MacOSUIElement>() {
                 macos_el.element.clone()
             } else {


### PR DESCRIPTION

### Description
Fixed a Rust borrow checker error (E0382) in the macOS platform implementation. The `actual_root` variable was being partially moved in a pattern match on line 3061, but then needed to be borrowed again later on line 3101 when calling `find_elements`.

The fix changes the pattern match from `if let Some(el) = actual_root` to `if let Some(ref el) = actual_root`, which borrows the value instead of moving it, allowing `actual_root` to remain available for later use.

### Type of Change
- [x] Build fix
