### PR TITLE
feat(mcp): add automatic VC++ redistributables installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,30 @@ To create reliable selectors (e.g. `name:Seven`, `role:Button`, `window:Calculat
 
 ## Troubleshooting
 
+### Windows: Visual C++ Redistributables
+
+**Automatic Installation (Default)**: Starting from v0.22.0, the MCP server automatically attempts to install Visual C++ Redistributables if missing. This happens silently in the background using:
+1. **winget** (Windows 11+, preferred method)
+2. **Direct download** (fallback for older Windows versions)
+
+**To disable auto-install**, set environment variable:
+```bash
+VCREDIST_AUTO_INSTALL=false
+```
+
+**Manual Installation**: If auto-install fails, install manually:
+```bash
+# Via winget (Windows 11+)
+winget install Microsoft.VCRedist.2015+.x64
+
+# Or download directly
+# https://aka.ms/vs/17/release/vc_redist.x64.exe
+```
+
+**Why required?**: Visual C++ Redistributables are needed for JavaScript/TypeScript execution via the `@mediar-ai/terminator` Node.js package.
+
+### Other Issues
+
 For detailed troubleshooting, debugging, and MCP server logs, [send us a message](https://www.mediar.ai/).
 
 ## Contributing


### PR DESCRIPTION
## Summary

Resolves #325 

Adds automatic installation of Visual C++ Redistributables when missing on Windows systems. This eliminates the installation blocker reported in the issue.

## Changes

### Core Implementation
- **`vcredist_check.rs`**: Added `try_auto_install_vcredist()` with two-tier strategy:
  1. **winget** (Windows 11+, preferred - clean package manager)
  2. **Direct download** (Windows 10 fallback - PowerShell download + silent install)

### Integration
- **`main.rs`**: Automatically triggers installation after detecting missing VC++ redistributables
- **README.md**: Documents the auto-install feature, manual override, and troubleshooting

## Features

✅ **Silent installation** - No user prompts, runs in background  
✅ **Graceful fallback** - winget → direct download → manual instructions  
✅ **Opt-out** - Set `VCREDIST_AUTO_INSTALL=false` to disable  
✅ **Full logging** - Clear messages for troubleshooting  
✅ **No restart required** - Installer runs with `/norestart` flag  

## Testing

- ✅ Builds successfully on Windows
- ✅ Handles missing winget gracefully
- ✅ PowerShell download fallback tested
- ✅ Environment variable override verified

## Technical Details

**Installation methods:**
1. **winget** (Windows 11+):
   ```bash
   winget install Microsoft.VCRedist.2015+.x64 --silent --accept-package-agreements
   ```

2. **Direct download** (fallback):
   - Downloads from: `https://aka.ms/vs/17/release/vc_redist.x64.exe`
   - Runs: `vc_redist.x64.exe /install /quiet /norestart`
   - Cleans up installer file automatically

## User Impact

**Before**: Users hit cryptic DLL errors when trying to use JavaScript/TypeScript features  
**After**: VC++ redistributables install automatically on first run

## Future Improvements

- [ ] Add progress indicators for download
- [ ] Verify installation success by re-checking DLLs
- [ ] Add retry logic with exponential backoff
- [ ] Consider bundling redistributables with installer (increases package size)

## Breaking Changes

None - this is purely additive. Existing behavior preserved, just adds auto-recovery.