### PR TITLE
feat: statically link CRT for Windows ARM64 builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,9 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
 
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
 # Optional sccache configuration - automatically used if RUSTC_WRAPPER=sccache is set
 # This speeds up compilation by caching builds across the project
 # To enable: Install sccache and set RUSTC_WRAPPER=sccache in your environment


### PR DESCRIPTION
### Summary

Statically link the C runtime for the `aarch64-pc-windows-msvc` target to eliminate dependency on external Visual C++ Redistributables.

The x64 target was already using static CRT linking — this change ensures parity for ARM64 builds.

* Removes runtime dependency on VC++ Redistributables for ARM64 builds
* Prevents installer/runtime crashes on systems missing VC++

#### Before

**ARM64 build dump (from CI):**
🔗 [Full log](https://github.com/mediar-ai/terminator/actions/runs/19055492977/job/54424642003#step:10:47)
```
Dump of file crates\terminator-mcp-agent\npm\win32-arm64-msvc\terminator-mcp-agent.exe

File Type: EXECUTABLE IMAGE

  Image has the following dependencies:

    kernel32.dll
    bcryptprimitives.dll
    api-ms-win-core-synch-l1-2-0.dll
    ws2_32.dll
    advapi32.dll
    ntdll.dll
    secur32.dll
    user32.dll
    oleaut32.dll
    pdh.dll
    psapi.dll
    shell32.dll
    powrprof.dll
    ole32.dll
    gdi32.dll
    propsys.dll
    dwmapi.dll
    api-ms-win-core-winrt-l1-1-0.dll
    bcrypt.dll
    crypt32.dll
    VCRUNTIME140.dll
    api-ms-win-crt-string-l1-1-0.dll
    api-ms-win-crt-math-l1-1-0.dll
    api-ms-win-crt-runtime-l1-1-0.dll
    api-ms-win-crt-stdio-l1-1-0.dll
    api-ms-win-crt-locale-l1-1-0.dll
    api-ms-win-crt-heap-l1-1-0.dll
```

**x64 build dump (same CI run):**
🔗 [Full log](https://github.com/mediar-ai/terminator/actions/runs/19055492977/job/54424642000#step:10:1)

```
Dump of file crates\terminator-mcp-agent\npm\win32-x64-msvc\terminator-mcp-agent.exe

File Type: EXECUTABLE IMAGE

  Image has the following dependencies:

    kernel32.dll
    bcryptprimitives.dll
    api-ms-win-core-synch-l1-2-0.dll
    ws2_32.dll
    advapi32.dll
    ntdll.dll
    secur32.dll
    user32.dll
    oleaut32.dll
    pdh.dll
    psapi.dll
    shell32.dll
    powrprof.dll
    ole32.dll
    gdi32.dll
    propsys.dll
    dwmapi.dll
    api-ms-win-core-winrt-l1-1-0.dll
    bcrypt.dll
    crypt32.dll
```

As seen, **the ARM64 binary depends on VCRUNTIME and CRT DLLs**, while the **x64 binary is fully statically linked**.

#### After


<img width="2622" height="1692" alt="Screenshot 2025-11-04 at 6 16 25 PM" src="https://github.com/user-attachments/assets/40431d4a-08e6-4f32-ba9a-b54560890a86" />



