### PR TITLE
feat(workflow): Rename createWorkflowError to WorkflowError

### DIFF
--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -8,7 +8,7 @@
 export { createStep } from './step';
 export { createWorkflow, WorkflowBuilder } from './workflow';
 export { createWorkflowRunner, WorkflowRunner } from './runner';
-export { createWorkflowError } from './types';
+export { WorkflowError, createWorkflowError } from './types';
 
 export type {
   Desktop,

--- a/packages/workflow/src/types.ts
+++ b/packages/workflow/src/types.ts
@@ -134,7 +134,7 @@ export interface ExecuteError {
  *
  * @example
  * ```typescript
- * throw createWorkflowError({
+ * throw WorkflowError({
  *   category: 'business',
  *   code: 'SAP_DUPLICATE_INVOICE',
  *   message: 'Invoice already exists in SAP',
@@ -143,7 +143,7 @@ export interface ExecuteError {
  * });
  * ```
  */
-export function createWorkflowError(error: ExecuteError): Error & ExecuteError {
+export function WorkflowError(error: ExecuteError): Error & ExecuteError {
   const err = new Error(error.message) as Error & ExecuteError;
   err.category = error.category;
   err.code = error.code;
@@ -151,6 +151,11 @@ export function createWorkflowError(error: ExecuteError): Error & ExecuteError {
   err.metadata = error.metadata;
   return err;
 }
+
+/**
+ * @deprecated Use WorkflowError instead (follows Error/TypeError naming convention)
+ */
+export const createWorkflowError = WorkflowError;
 
 /**
  * Workflow execution response


### PR DESCRIPTION
## Summary
Renames `createWorkflowError()` to `WorkflowError()` to follow JavaScript/TypeScript naming conventions.

## Changes
- Add `WorkflowError()` function with constructor-style naming
- Keep `createWorkflowError` as deprecated alias (backward compatible)
- Update JSDoc examples
- Export both names

## Related
Closes #373