### PR TITLE
docs: improve CLI installation instructions with npm wrapper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,12 +3,28 @@
 Open-source desktop automation (MIT). Gives AI hands to control any app on Windows/macOS/Linux.
 **Mediar AI** | [$2.8M seed](https://x.com/louis030195/status/1948745185178914929) | [mediar.ai](https://mediar.ai)
 
+## Installation
+
+**Windows (Primary Platform):**
+```bash
+npx @mediar-ai/cli --help  # Run without install
+npm i -g @mediar-ai/cli    # Or install globally
+```
+
+**macOS/Linux (Experimental):**
+Compile from source - npm wrapper only includes Windows binaries.
+```bash
+cargo build --release
+```
+
 ## Release
 
 **CRITICAL**: Use `terminator` CLI only (syncs versions across workspace).
 
 ```bash
-cargo install --path terminator-cli  # Once
+# Windows: use npx @mediar-ai/cli or installed CLI
+# Others: compile from source first
+cargo install --path crates/terminator-cli  # Once
 terminator release                   # Bump patch → tag → push (triggers CI/CD)
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,15 @@ terminator tag                         # Tag and push current version
 
 ### Installation (Run Once)
 
+**Windows (Recommended):**
 ```bash
-cargo install --path terminator-cli   # Install globally to PATH
+npm install -g @mediar-ai/cli        # npm wrapper with Windows binaries
+# Then use: terminator release
+```
+
+**macOS/Linux (Compile from source):**
+```bash
+cargo install --path crates/terminator-cli   # Install globally to PATH
 ```
 
 ### CLI Help

--- a/README.md
+++ b/README.md
@@ -71,6 +71,39 @@ We achieve this by pre-training workflows as deterministic code, and calling AI 
 - Deploy AI to execute them at >95% success rate
 - Kill repetitive work without legacy RPA complexity or cost
 
+## 📥 Installation
+
+### Terminator CLI
+
+**Windows (Recommended):**
+```bash
+# Run directly without installation
+npx @mediar-ai/cli --help
+bunx @mediar-ai/cli --help
+
+# Or install globally
+npm install -g @mediar-ai/cli
+```
+
+**macOS / Linux (Experimental - Compile from Source):**
+
+⚠️ **Warning:** macOS and Linux support is experimental. Many features are Windows-only or incomplete on other platforms.
+
+```bash
+git clone https://github.com/mediar-ai/terminator
+cd terminator
+cargo build --release
+# Binary at: ./target/release/terminator
+```
+
+### Platform Support
+
+| Platform | CLI | MCP Agent | Automation | Installation Method |
+|----------|:---:|:---------:|:----------:|---------------------|
+| Windows  | ✅  | ✅        | ✅         | npm/bunx |
+| macOS    | 🟡  | ✅        | 🟡         | Compile from source |
+| Linux    | 🟡  | ✅        | 🟡         | Compile from source |
+
 ## 🎯 Choose Your Path
 
 ### 🤖 Want AI Automation with Claude Code? (Recommended for Most Users)

--- a/crates/terminator-cli/README.md
+++ b/crates/terminator-cli/README.md
@@ -14,14 +14,26 @@ The Terminator CLI is a powerful command-line tool for managing the Terminator p
 
 ## Installation
 
-From the workspace root:
+**Windows (Recommended - npm wrapper):**
+```bash
+# Run directly without installation
+npx @mediar-ai/cli --help
+bunx @mediar-ai/cli --help
+
+# Or install globally
+npm install -g @mediar-ai/cli
+```
+
+**macOS / Linux (Compile from Source):**
+
+⚠️ The npm package `@mediar-ai/cli` only includes Windows binaries. Other platforms must compile from source.
 
 ```bash
-# Build the CLI
+# From the workspace root
 cargo build --release --bin terminator
 
 # Install globally (optional)
-cargo install --path terminator-cli
+cargo install --path crates/terminator-cli
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary

- Add npx/bunx installation instructions as the recommended method for Windows users
- Clarify that macOS/Linux support is experimental and requires compiling from source
- Add platform support matrix to README
- Update all documentation files consistently

## Changes

### README.md
- Added **Installation** section with platform-specific instructions
- Added platform support matrix showing Windows (npm), macOS/Linux (compile from source)
- Positioned before "Choose Your Path" for better discoverability

### CLAUDE.md
- Added **Installation** section with npm wrapper for Windows
- Updated Release section to mention platform-specific installation

### CONTRIBUTING.md
- Updated CLI installation with separate Windows (npm) and macOS/Linux (cargo) instructions

### crates/terminator-cli/README.md
- Added npm wrapper as primary installation method for Windows
- Added warning that npm package only includes Windows binaries

## Why These Changes?

The `@mediar-ai/cli` npm package provides a convenient wrapper around the Rust CLI binary, but this wasn't documented anywhere. Users had to:
1. Manually download releases
2. Compile from source
3. Or discover the npm package by accident

This PR makes the easiest installation method (npx/bunx) the most visible, while being clear about platform limitations.

## Test Plan

- [x] Verified all documentation changes are consistent
- [x] Checked that platform warnings are clear
- [x] Confirmed npm package name is correct (@mediar-ai/cli)

🤖 Generated with [Claude Code](https://claude.com/claude-code)