### PR TITLE
fix: pass execution_id as structured tracing field instead of message prefix

### DIFF
--- a/crates/terminator-mcp-agent/src/workflow_typescript.rs
+++ b/crates/terminator-mcp-agent/src/workflow_typescript.rs
@@ -423,7 +423,6 @@ impl TypeScriptWorkflow {
             }
         };
 
-
         // Take stderr and spawn a task to stream logs through tracing
         // execution_id is passed as a structured field for OpenTelemetry/ClickHouse filtering
         let stderr = child.stderr.take();

--- a/crates/terminator-mcp-agent/tests/test_typescript_telemetry.rs
+++ b/crates/terminator-mcp-agent/tests/test_typescript_telemetry.rs
@@ -7,7 +7,7 @@
 #[cfg(test)]
 mod typescript_telemetry_tests {
     use std::sync::{Arc, Mutex};
-    use tracing::{info, info_span, Instrument};
+    use tracing::{error, info, info_span, warn, Instrument};
     use tracing_subscriber::layer::SubscriberExt;
 
     #[derive(Debug, Clone)]
@@ -31,21 +31,29 @@ mod typescript_telemetry_tests {
             ctx: tracing_subscriber::layer::Context<'_, S>,
         ) {
             let mut message = String::new();
-            let mut visitor = MessageVisitor(&mut message);
+            let mut event_execution_id = None;
+            let mut visitor = EventFieldVisitor {
+                message: &mut message,
+                execution_id: &mut event_execution_id,
+            };
             event.record(&mut visitor);
 
-            let mut execution_id = None;
+            // Event-level execution_id takes precedence
+            let mut execution_id = event_execution_id;
             let mut trace_id = None;
 
-            if let Some(scope) = ctx.event_scope(event) {
-                for span in scope {
-                    let extensions = span.extensions();
-                    if let Some(fields) = extensions.get::<SpanFields>() {
-                        if execution_id.is_none() {
-                            execution_id = fields.execution_id.clone();
-                        }
-                        if trace_id.is_none() {
-                            trace_id = fields.trace_id.clone();
+            // Also check span-level fields if event-level not found
+            if execution_id.is_none() || trace_id.is_none() {
+                if let Some(scope) = ctx.event_scope(event) {
+                    for span in scope {
+                        let extensions = span.extensions();
+                        if let Some(fields) = extensions.get::<SpanFields>() {
+                            if execution_id.is_none() {
+                                execution_id = fields.execution_id.clone();
+                            }
+                            if trace_id.is_none() {
+                                trace_id = fields.trace_id.clone();
+                            }
                         }
                     }
                 }
@@ -101,18 +109,26 @@ mod typescript_telemetry_tests {
         }
     }
 
-    struct MessageVisitor<'a>(&'a mut String);
+    /// Visitor that captures both message and event-level execution_id
+    struct EventFieldVisitor<'a> {
+        message: &'a mut String,
+        execution_id: &'a mut Option<String>,
+    }
 
-    impl<'a> tracing::field::Visit for MessageVisitor<'a> {
+    impl<'a> tracing::field::Visit for EventFieldVisitor<'a> {
         fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-            if field.name() == "message" {
-                *self.0 = value.to_string();
+            match field.name() {
+                "message" => *self.message = value.to_string(),
+                "execution_id" => *self.execution_id = Some(value.to_string()),
+                _ => {}
             }
         }
 
         fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-            if field.name() == "message" {
-                *self.0 = format!("{value:?}");
+            match field.name() {
+                "message" => *self.message = format!("{value:?}"),
+                "execution_id" => *self.execution_id = Some(format!("{value:?}")),
+                _ => {}
             }
         }
     }
@@ -222,5 +238,120 @@ mod typescript_telemetry_tests {
                 log.message
             );
         }
+    }
+
+    /// Test that execution_id passed as event-level field is captured correctly
+    /// This verifies the new behavior where execution_id is a structured field
+    /// rather than being embedded in the message body
+    #[test]
+    fn test_event_level_execution_id_field() {
+        let logs = Arc::new(Mutex::new(Vec::new()));
+        let layer = TestCapturingLayer { logs: logs.clone() };
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            // Simulate the new logging pattern used in workflow_typescript.rs
+            // where execution_id is passed as a structured field
+            info!(
+                target: "workflow.typescript",
+                execution_id = %"exec-12345",
+                "Step completed successfully"
+            );
+            warn!(
+                target: "workflow.typescript",
+                execution_id = %"exec-12345",
+                "Warning during execution"
+            );
+            error!(
+                target: "workflow.typescript",
+                execution_id = %"exec-12345",
+                "Error occurred"
+            );
+        });
+
+        let captured = logs.lock().unwrap();
+        assert_eq!(captured.len(), 3, "Expected 3 logs");
+
+        for log in captured.iter() {
+            // Verify execution_id is captured as structured field
+            assert_eq!(
+                log.execution_id.as_deref(),
+                Some("exec-12345"),
+                "Log '{}' should have execution_id as structured field",
+                log.message
+            );
+
+            // Verify message does NOT contain [execution_id=...] prefix
+            assert!(
+                !log.message.contains("[execution_id="),
+                "Message '{}' should NOT contain execution_id prefix in body",
+                log.message
+            );
+        }
+
+        // Verify specific messages
+        assert!(captured[0].message.contains("Step completed"));
+        assert!(captured[1].message.contains("Warning"));
+        assert!(captured[2].message.contains("Error"));
+    }
+
+    /// Test that logs without execution_id work correctly
+    #[test]
+    fn test_log_without_execution_id() {
+        let logs = Arc::new(Mutex::new(Vec::new()));
+        let layer = TestCapturingLayer { logs: logs.clone() };
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            // Simulate logging without execution_id (when execution_id is None)
+            info!(target: "workflow.typescript", "Log without execution context");
+        });
+
+        let captured = logs.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert!(
+            captured[0].execution_id.is_none(),
+            "execution_id should be None when not provided"
+        );
+        assert!(captured[0]
+            .message
+            .contains("Log without execution context"));
+    }
+
+    /// Test that message body is clean (no execution_id prefix)
+    /// This is the key behavior change: execution_id should be in the structured
+    /// field, not embedded in the message like "[execution_id=XXX] message"
+    #[test]
+    fn test_message_body_is_clean() {
+        let logs = Arc::new(Mutex::new(Vec::new()));
+        let layer = TestCapturingLayer { logs: logs.clone() };
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            // The message should be clean, with execution_id as a separate field
+            info!(
+                target: "workflow.typescript",
+                execution_id = %"99999",
+                "Browser navigation completed"
+            );
+        });
+
+        let captured = logs.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+
+        let log = &captured[0];
+
+        // The message should be exactly "Browser navigation completed"
+        // NOT "[execution_id=99999] Browser navigation completed"
+        assert_eq!(
+            log.message, "Browser navigation completed",
+            "Message should be clean without execution_id prefix"
+        );
+
+        // But execution_id should still be available as structured field
+        assert_eq!(log.execution_id.as_deref(), Some("99999"));
     }
 }


### PR DESCRIPTION
## Summary
Removes `[execution_id=XXX]` prefix from log message body and passes it as a structured tracing field instead.

## Changes
- Log messages no longer contain the execution_id prefix in the message body
- execution_id is passed as a structured field to tracing macros (`execution_id = %exec_id`)
- OpenTelemetry/ClickHouse filtering still works via OTEL attributes

## Before
```
[execution_id=25369] Step completed successfully
```

## After
```
Step completed successfully
```
(with `execution_id=25369` available as OTEL attribute for filtering)

## Testing
- Existing `parse_log_line` tests pass
- No functional changes to log parsing logic