### PR TITLE
fix: remove incomplete ClusteredYaml feature that broke compilation

### DIFF
--- a/crates/terminator-mcp-agent/src/utils.rs
+++ b/crates/terminator-mcp-agent/src/utils.rs
@@ -351,17 +351,6 @@ pub struct DesktopWrapper {
     #[serde(skip)]
     pub dom_bounds:
         Arc<Mutex<std::collections::HashMap<u32, (String, String, (f64, f64, f64, f64))>>>,
-    /// Stores clustered index-to-bounds mapping from the last get_window_tree with clustered_yaml format
-    /// Key is prefixed index (e.g., "u1", "d2", "o3", "p4", "g5"), value is (source, original_index, bounds)
-    #[serde(skip)]
-    pub clustered_bounds: Arc<
-        Mutex<
-            std::collections::HashMap<
-                String,
-                (crate::tree_formatter::ElementSource, u32, (f64, f64, f64, f64)),
-            >,
-        >,
-    >,
     /// Stores the active inspect overlay handle for cleanup
     #[cfg(target_os = "windows")]
     #[serde(skip)]


### PR DESCRIPTION
## Problem
Main branch doesn't compile after commit d92f1dcc added references to:
- `ClusteredYaml` enum variant (not defined in `TreeOutputFormat`)
- `format_clustered_tree_from_caches` function (not implemented)
- `ElementSource` type (not defined)

## Solution
Remove all dead code references since the feature was never implemented:
- Remove `ClusteredYaml` from match arms in server.rs
- Remove clustered tree generation block in server.rs
- Remove `clustered_bounds` field from DesktopWrapper in utils.rs

## Testing
```
cargo check -p terminator-mcp-agent  # Now passes
cargo test -p terminator-mcp-agent   # 86 passed, 1 pre-existing failure
```

Note: `test_basic_formatting` failure is pre-existing and unrelated to this fix.