### PR TITLE
feat: add trigger/cron scheduling support for TypeScript workflows

### DIFF
--- a/crates/terminator-mcp-agent/src/workflow_typescript.rs
+++ b/crates/terminator-mcp-agent/src/workflow_typescript.rs
@@ -1309,6 +1309,26 @@ pub struct TypeScriptWorkflowExecutionResult {
     pub logs: Vec<CapturedLogEntry>,
 }
 
+/// Trigger configuration for workflows
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum TriggerConfig {
+    /// Cron-based scheduling
+    Cron {
+        /// Cron expression (5-field or 6-field format)
+        schedule: String,
+        /// Optional timezone (IANA format)
+        timezone: Option<String>,
+    },
+    /// Manual trigger (default)
+    Manual,
+    /// Webhook trigger
+    Webhook {
+        /// Optional webhook path suffix
+        path: Option<String>,
+    },
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct WorkflowMetadata {
     pub name: String,
@@ -1316,6 +1336,9 @@ pub struct WorkflowMetadata {
     pub version: Option<String>,
     pub input: Value,
     pub steps: Vec<StepMetadata>,
+    /// Trigger configuration for the workflow
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger: Option<TriggerConfig>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -54,6 +54,11 @@ export type {
     WorkflowExecutionContext,
     WorkflowSuccessContext,
     WorkflowErrorContext,
+    // Trigger types
+    TriggerConfig,
+    CronTrigger,
+    ManualTrigger,
+    WebhookTrigger,
 } from "./types";
 
 export type { WorkflowRunnerOptions, WorkflowState } from "./runner";

--- a/packages/workflow/src/types.ts
+++ b/packages/workflow/src/types.ts
@@ -420,6 +420,59 @@ export interface Step<
 }
 
 /**
+ * Cron trigger configuration
+ *
+ * @example
+ * ```typescript
+ * trigger: {
+ *   type: 'cron',
+ *   schedule: '0 9 * * 1-5', // Every weekday at 9am
+ *   timezone: 'America/New_York'
+ * }
+ * ```
+ */
+export interface CronTrigger {
+    type: 'cron';
+    /** Cron expression (5-field or 6-field format) */
+    schedule: string;
+    /** Optional timezone (IANA format, e.g., 'America/New_York') */
+    timezone?: string;
+}
+
+/**
+ * Manual trigger - workflow must be triggered explicitly
+ */
+export interface ManualTrigger {
+    type: 'manual';
+}
+
+/**
+ * Webhook trigger - workflow triggered via HTTP endpoint
+ */
+export interface WebhookTrigger {
+    type: 'webhook';
+    /** Optional webhook path suffix */
+    path?: string;
+}
+
+/**
+ * Trigger configuration for workflows
+ *
+ * @example
+ * ```typescript
+ * // Cron trigger - runs on schedule
+ * trigger: { type: 'cron', schedule: '0 0,6,12,18 * * *' }
+ *
+ * // Manual trigger (default)
+ * trigger: { type: 'manual' }
+ *
+ * // Webhook trigger
+ * trigger: { type: 'webhook', path: '/my-workflow' }
+ * ```
+ */
+export type TriggerConfig = CronTrigger | ManualTrigger | WebhookTrigger;
+
+/**
  * Workflow configuration (user-facing)
  *
  * Note: name, version, and description are automatically read from package.json.
@@ -430,6 +483,25 @@ export interface WorkflowConfig<TInput = any> {
     input: z.ZodSchema<TInput>;
     /** Optional tags */
     tags?: string[];
+    /**
+     * Trigger configuration for the workflow.
+     * Defines when/how the workflow should be executed.
+     *
+     * @default { type: 'manual' }
+     *
+     * @example
+     * ```typescript
+     * // Run every day at 9am
+     * trigger: { type: 'cron', schedule: '0 9 * * *' }
+     *
+     * // Run every 6 hours
+     * trigger: { type: 'cron', schedule: '0 0,6,12,18 * * *' }
+     *
+     * // Run on weekdays at 8:30am EST
+     * trigger: { type: 'cron', schedule: '30 8 * * 1-5', timezone: 'America/New_York' }
+     * ```
+     */
+    trigger?: TriggerConfig;
     /** Steps to execute in sequence */
     steps?: Step[];
     /**
@@ -454,6 +526,7 @@ export interface WorkflowConfig<TInput = any> {
         context: WorkflowErrorContext<TInput>,
     ) => Promise<ExecutionResponse | void>;
 }
+
 
 /**
  * Internal resolved workflow configuration with metadata from package.json
@@ -554,6 +627,7 @@ export interface Workflow<TInput = any> {
             name: string;
             description?: string;
         }>;
+        trigger?: TriggerConfig;
     };
 }
 

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -232,6 +232,7 @@ function createWorkflowInstance<TInput = any>(
                                 name: s.config.name,
                                 description: s.config.description,
                             })),
+                            trigger: config.trigger,
                         };
                     },
                 };
@@ -530,6 +531,7 @@ function createWorkflowInstance<TInput = any>(
                 version: config.version,
                 input: config.input,
                 steps: steps.map((s) => s.getMetadata()),
+                trigger: config.trigger,
             };
         },
     };


### PR DESCRIPTION
## Summary
- Adds `TriggerConfig` types (`CronTrigger`, `ManualTrigger`, `WebhookTrigger`) to the workflow SDK
- Adds optional `trigger` field to `WorkflowConfig` for defining when workflows should run
- Updates MCP agent to include trigger metadata in workflow responses

## Example Usage
```typescript
const workflow = createWorkflow({
  input: z.object({ ... }),
  trigger: {
    type: 'cron',
    schedule: '0 9 * * 1-5', // Every weekday at 9am
    timezone: 'America/New_York'
  },
  steps: [...]
});
```

## Test plan
- [x] TypeScript workflow package builds successfully
- [x] Rust MCP agent compiles
- [x] All existing tests pass
- [ ] Integration test with mediar-app cron scheduler

🤖 Generated with [Claude Code](https://claude.com/claude-code)