### PR TITLE
feat(desktop): add closeTab method for safe browser tab closing

### DIFF
--- a/crates/terminator-mcp-agent/src/server.rs
+++ b/crates/terminator-mcp-agent/src/server.rs
@@ -9916,7 +9916,13 @@ impl DesktopWrapper {
                 match serde_json::from_value::<ExecuteSequenceArgs>(arguments.clone()) {
                     Ok(args) => {
                         let client_progress_token = request_context.meta.get_progress_token();
-                        Box::pin(self.execute_sequence_impl(peer, request_context, client_progress_token, args)).await
+                        Box::pin(self.execute_sequence_impl(
+                            peer,
+                            request_context,
+                            client_progress_token,
+                            args,
+                        ))
+                        .await
                     }
                     Err(e) => Err(McpError::invalid_params(
                         "Invalid arguments for execute_sequence",

--- a/crates/terminator-mcp-agent/src/server_sequence.rs
+++ b/crates/terminator-mcp-agent/src/server_sequence.rs
@@ -2473,10 +2473,15 @@ impl DesktopWrapper {
             let (event_tx, mut event_rx) = mpsc::unbounded_channel::<WorkflowEvent>();
 
             // Use client's progress token if provided, otherwise generate one
-            info!("client_progress_token received: {:?}", client_progress_token);
-            let progress_token = client_progress_token.unwrap_or_else(|| ProgressToken(NumberOrString::String(
-                format!("workflow-{}", execution_id_val).into(),
-            )));
+            info!(
+                "client_progress_token received: {:?}",
+                client_progress_token
+            );
+            let progress_token = client_progress_token.unwrap_or_else(|| {
+                ProgressToken(NumberOrString::String(
+                    format!("workflow-{}", execution_id_val).into(),
+                ))
+            });
 
             // Shared storage for collecting screenshots from events with metadata
             // (index, timestamp, annotation, element, base64)

--- a/crates/terminator/src/lib.rs
+++ b/crates/terminator/src/lib.rs
@@ -1169,7 +1169,49 @@ impl Desktop {
             }
         }
     }
-
+    /// Close a browser tab safely using the browser extension
+    ///
+    /// This method can identify the tab to close by:
+    /// - tab_id: Close a specific tab by its Chrome tab ID
+    /// - url: Find and close a tab matching this URL
+    /// - title: Find and close a tab matching this title
+    /// - If none provided, closes the currently active tab
+    ///
+    /// Returns information about the closed tab for verification.
+    /// Returns None if no extension is connected or tab couldn't be found.
+    ///
+    /// # Safety
+    /// - Will NOT close protected browser pages (chrome://, about:, etc.)
+    /// - Returns the closed tab's URL/title so you can verify the right tab was closed
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use terminator::Desktop;
+    /// use std::time::Duration;
+    ///
+    /// async fn example() {
+    ///     let desktop = Desktop::new_default().unwrap();
+    ///     
+    ///     // Close by URL
+    ///     let result = desktop.close_tab(None, Some("example.com"), None).await;
+    ///     
+    ///     // Close by title
+    ///     let result = desktop.close_tab(None, None, Some("My Tab")).await;
+    ///     
+    ///     // Close active tab
+    ///     let result = desktop.close_tab(None, None, None).await;
+    /// }
+    /// ```
+    #[instrument(skip(self))]
+    pub async fn close_tab(
+        &self,
+        tab_id: Option<i32>,
+        url: Option<&str>,
+        title: Option<&str>,
+    ) -> Result<Option<extension_bridge::CloseTabResult>, AutomationError> {
+        use std::time::Duration;
+        extension_bridge::try_close_tab(tab_id, url, title, Duration::from_secs(10)).await
+    }
     #[instrument(skip(self))]
     pub async fn get_current_window(&self) -> Result<UIElement, AutomationError> {
         self.engine.get_current_window().await

--- a/crates/terminator/src/tests/close_tab_tests.rs
+++ b/crates/terminator/src/tests/close_tab_tests.rs
@@ -1,0 +1,59 @@
+//! Tests for the close_tab functionality
+
+use crate::extension_bridge::{CloseTabResult, ClosedTabInfo};
+
+#[test]
+fn test_close_tab_result_structure() {
+    // Test that CloseTabResult can be constructed and serialized
+    let result = CloseTabResult {
+        closed: true,
+        tab: ClosedTabInfo {
+            id: 123,
+            url: Some("https://example.com".to_string()),
+            title: Some("Example Page".to_string()),
+            window_id: Some(1),
+        },
+    };
+
+    assert!(result.closed);
+    assert_eq!(result.tab.id, 123);
+    assert_eq!(result.tab.url, Some("https://example.com".to_string()));
+    assert_eq!(result.tab.title, Some("Example Page".to_string()));
+    assert_eq!(result.tab.window_id, Some(1));
+}
+
+#[test]
+fn test_close_tab_result_serialization() {
+    let result = CloseTabResult {
+        closed: true,
+        tab: ClosedTabInfo {
+            id: 456,
+            url: Some("https://test.com".to_string()),
+            title: None,
+            window_id: None,
+        },
+    };
+
+    // Test JSON serialization
+    let json = serde_json::to_string(&result).expect("Should serialize");
+    assert!(json.contains("\"closed\":true"));
+    assert!(json.contains("\"id\":456"));
+    assert!(json.contains("\"url\":\"https://test.com\""));
+
+    // Test deserialization
+    let parsed: CloseTabResult = serde_json::from_str(&json).expect("Should deserialize");
+    assert!(parsed.closed);
+    assert_eq!(parsed.tab.id, 456);
+}
+
+#[test]
+fn test_close_tab_result_with_null_fields() {
+    let json = r#"{"closed":true,"tab":{"id":789,"url":null,"title":null,"windowId":null}}"#;
+    let result: CloseTabResult = serde_json::from_str(json).expect("Should parse with nulls");
+
+    assert!(result.closed);
+    assert_eq!(result.tab.id, 789);
+    assert!(result.tab.url.is_none());
+    assert!(result.tab.title.is_none());
+    assert!(result.tab.window_id.is_none());
+}

--- a/crates/terminator/src/tests/mod.rs
+++ b/crates/terminator/src/tests/mod.rs
@@ -1,4 +1,6 @@
 mod boolean_selector_tests;
+#[cfg(test)]
+mod close_tab_tests;
 mod e2e_tests;
 mod firefox_window_tests;
 mod functional_verification_tests;

--- a/crates/terminator/tests/close_tab_e2e_test.rs
+++ b/crates/terminator/tests/close_tab_e2e_test.rs
@@ -1,0 +1,117 @@
+//! End-to-end tests for close_tab functionality
+//!
+//! These tests require:
+//! - Chrome browser installed
+//! - Terminator browser extension installed and enabled
+
+use std::time::Duration;
+use terminator::{Browser, Desktop};
+use terminator::extension_bridge::ExtensionBridge;
+use tracing::info;
+
+/// Test closing a tab by URL
+#[tokio::test]
+#[ignore = "requires browser with extension installed"]
+async fn test_close_tab_by_url() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("debug")
+        .with_test_writer()
+        .try_init();
+
+    // Initialize the bridge FIRST so extension can connect
+    info!("Initializing extension bridge...");
+    let bridge = ExtensionBridge::global().await;
+    
+    // Wait for extension to connect (it should auto-reconnect)
+    info!("Waiting for extension to connect...");
+    for i in 0..20 {
+        if bridge.is_client_connected().await {
+            info!("Extension connected after {}ms", i * 500);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    
+    if !bridge.is_client_connected().await {
+        panic!("Extension did not connect within 10 seconds - is it installed in Chrome?");
+    }
+
+    let desktop = Desktop::new(false, false).expect("Failed to create Desktop");
+
+    // Open a test URL
+    let test_url = "https://example.com/";
+    info!("Opening URL: {}", test_url);
+
+    let element = desktop
+        .open_url(test_url, Some(Browser::Chrome))
+        .expect("Failed to open URL");
+
+    info!("Opened browser window: {:?}", element.name());
+
+    // Wait for page to load
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Close the tab by URL
+    info!("Attempting to close tab by URL: {}", test_url);
+    let result = desktop
+        .close_tab(None, Some("example.com"), None)
+        .await
+        .expect("close_tab failed");
+
+    match result {
+        Some(closed_info) => {
+            info!("Successfully closed tab: {:?}", closed_info);
+            assert!(closed_info.closed, "Tab should be marked as closed");
+            assert!(
+                closed_info.tab.url.as_ref().map(|u| u.contains("example.com")).unwrap_or(false),
+                "Closed tab URL should contain example.com, got: {:?}", closed_info.tab.url
+            );
+        }
+        None => {
+            panic!("close_tab returned None - something went wrong");
+        }
+    }
+}
+
+/// Test closing active tab
+#[tokio::test]
+#[ignore = "requires browser with extension installed"]  
+async fn test_close_active_tab() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("debug")
+        .with_test_writer()
+        .try_init();
+
+    let bridge = ExtensionBridge::global().await;
+    
+    // Wait for extension
+    for _ in 0..20 {
+        if bridge.is_client_connected().await { break; }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    
+    if !bridge.is_client_connected().await {
+        panic!("Extension not connected");
+    }
+
+    let desktop = Desktop::new(false, false).expect("Failed to create Desktop");
+
+    // Open test URL
+    desktop
+        .open_url("https://httpbin.org/html", Some(Browser::Chrome))
+        .expect("Failed to open URL");
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Close active tab
+    info!("Closing active tab...");
+    let result = desktop
+        .close_tab(None, None, None)
+        .await
+        .expect("close_tab failed");
+
+    assert!(result.is_some(), "Should have closed a tab");
+    let closed = result.unwrap();
+    info!("Closed: id={}, url={:?}", closed.tab.id, closed.tab.url);
+    assert!(closed.closed);
+}

--- a/packages/terminator-nodejs/src/desktop.rs
+++ b/packages/terminator-nodejs/src/desktop.rs
@@ -2444,6 +2444,49 @@ impl Desktop {
             .map_err(map_error)
     }
 
+    /// (async) Close a browser tab safely.
+    ///
+    /// This method can identify the tab to close by:
+    /// - tabId: Close a specific tab by its Chrome tab ID
+    /// - url: Find and close a tab matching this URL (partial match supported)
+    /// - title: Find and close a tab matching this title (case-insensitive partial match)
+    /// - If none provided, closes the currently active tab
+    ///
+    /// Returns information about the closed tab for verification.
+    /// Returns null if no browser extension is connected or tab couldn't be found.
+    ///
+    /// Safety:
+    /// - Will NOT close protected browser pages (chrome://, edge://, about:, etc.)
+    /// - Returns the closed tab's URL/title so you can verify the correct tab was closed
+    ///
+    /// @param {number} [tabId] - Specific Chrome tab ID to close.
+    /// @param {string} [url] - URL to match (partial match supported).
+    /// @param {string} [title] - Title to match (case-insensitive partial match).
+    /// @returns {Promise<CloseTabResult | null>} Info about closed tab, or null if no extension/tab found.
+    ///
+    /// @example
+    /// // Close by URL
+    /// const result = await desktop.closeTab({ url: "example.com" });
+    ///
+    /// @example
+    /// // Close by title
+    /// const result = await desktop.closeTab({ title: "My Page" });
+    ///
+    /// @example
+    /// // Close active tab
+    /// const result = await desktop.closeTab();
+    #[napi]
+    pub async fn close_tab(
+        &self,
+        options: Option<crate::types::CloseTabOptions>,
+    ) -> napi::Result<Option<crate::types::CloseTabResult>> {
+        let opts = options.unwrap_or_default();
+        self.inner
+            .close_tab(opts.tab_id, opts.url.as_deref(), opts.title.as_deref())
+            .await
+            .map(|opt| opt.map(crate::types::CloseTabResult::from))
+            .map_err(map_error)
+    }
     /// (async) Delay execution for a specified number of milliseconds.
     /// Useful for waiting between actions to ensure UI stability.
     ///

--- a/packages/terminator-nodejs/src/types.rs
+++ b/packages/terminator-nodejs/src/types.rs
@@ -917,3 +917,47 @@ impl From<terminator::ComputerUseResult> for ComputerUseResult {
         }
     }
 }
+
+/// Result of closing a browser tab
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct CloseTabResult {
+    pub closed: bool,
+    pub tab: ClosedTabInfo,
+}
+
+/// Information about a closed tab
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct ClosedTabInfo {
+    pub id: i32,
+    pub url: Option<String>,
+    pub title: Option<String>,
+    pub window_id: Option<i32>,
+}
+
+impl From<terminator::extension_bridge::CloseTabResult> for CloseTabResult {
+    fn from(result: terminator::extension_bridge::CloseTabResult) -> Self {
+        CloseTabResult {
+            closed: result.closed,
+            tab: ClosedTabInfo {
+                id: result.tab.id,
+                url: result.tab.url,
+                title: result.tab.title,
+                window_id: result.tab.window_id,
+            },
+        }
+    }
+}
+
+/// Options for closing a browser tab
+#[napi(object)]
+#[derive(Debug, Clone, Default)]
+pub struct CloseTabOptions {
+    /// Specific Chrome tab ID to close
+    pub tab_id: Option<i32>,
+    /// URL to match (partial match supported)
+    pub url: Option<String>,
+    /// Title to match (case-insensitive partial match)
+    pub title: Option<String>,
+}


### PR DESCRIPTION
## Summary

- Adds `closeTab()` method to Desktop API for safely closing browser tabs via Chrome extension
- Supports multiple identification methods: tab ID, URL match, or title match
- Safety features prevent closing protected pages (chrome://, about:, edge://)
- Returns closed tab info for verification

## API

```javascript
// Close by URL (partial match)
const result = await desktop.closeTab({ url: "example.com" });

// Close by title (case-insensitive partial match)
const result = await desktop.closeTab({ title: "My Tab" });

// Close active tab  
const result = await desktop.closeTab({});

// Result contains closed tab info for verification
console.log(result); // { closed: true, tab: { id: 123, url: "...", title: "..." } }
```

## Implementation

1. **worker.js**: Added `close_tab` message handler and `closeTab()` function
2. **extension_bridge.rs**: Added `CloseTabRequest`/`CloseTabResult` types and `close_tab()` method  
3. **lib.rs**: Added `close_tab()` to Desktop struct
4. **desktop.rs (nodejs)**: Exposed via napi bindings
5. **types.rs (nodejs)**: Added TypeScript types

## Test plan

- [ ] Verify closeTab closes tab by URL match
- [ ] Verify closeTab closes tab by title match  
- [ ] Verify closeTab closes active tab when no params provided
- [ ] Verify protected pages (chrome://) cannot be closed
- [ ] Verify returns null when no extension connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)