### PR TITLE
Fix python binding for TreeBuildConfig

### DIFF
--- a/packages/terminator-python/src/types.rs
+++ b/packages/terminator-python/src/types.rs
@@ -180,38 +180,18 @@ pub struct PropertyLoadingMode {
     pub mode: String,
 }
 
-impl PropertyLoadingMode {
-    pub fn fast() -> Self {
-        PropertyLoadingMode {
-            mode: "Fast".to_string(),
-        }
-    }
-
-    pub fn complete() -> Self {
-        PropertyLoadingMode {
-            mode: "Complete".to_string(),
-        }
-    }
-
-    pub fn smart() -> Self {
-        PropertyLoadingMode {
-            mode: "Smart".to_string(),
-        }
-    }
-}
-
 /// Configuration for tree building performance and completeness
 #[gen_stub_pyclass]
 #[pyclass(name = "TreeBuildConfig")]
 #[derive(Clone, Serialize)]
 pub struct TreeBuildConfig {
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub property_mode: PropertyLoadingMode,
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub timeout_per_operation_ms: Option<u64>,
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub yield_every_n_elements: Option<usize>,
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub batch_size: Option<usize>,
 }
 
@@ -627,6 +607,27 @@ impl UINode {
 #[gen_stub_pymethods]
 #[pymethods]
 impl PropertyLoadingMode {
+    #[staticmethod]
+    pub fn fast() -> Self {
+        PropertyLoadingMode {
+            mode: "Fast".to_string(),
+        }
+    }
+
+    #[staticmethod]
+    pub fn complete() -> Self {
+        PropertyLoadingMode {
+            mode: "Complete".to_string(),
+        }
+    }
+
+    #[staticmethod]
+    pub fn smart() -> Self {
+        PropertyLoadingMode {
+            mode: "Smart".to_string(),
+        }
+    }
+
     fn __repr__(&self) -> PyResult<String> {
         serde_json::to_string(self)
             .map_err(|e| pyo3::exceptions::PyException::new_err(e.to_string()))
@@ -653,6 +654,16 @@ impl Monitor {
 #[gen_stub_pymethods]
 #[pymethods]
 impl TreeBuildConfig {
+    #[new]
+    pub fn new() -> Self {
+        Self {
+            property_mode: PropertyLoadingMode::fast(), // default
+            timeout_per_operation_ms: None,
+            yield_every_n_elements: None,
+            batch_size: None,
+        }
+    }
+
     fn __repr__(&self) -> PyResult<String> {
         serde_json::to_string(self)
             .map_err(|e| pyo3::exceptions::PyException::new_err(e.to_string()))

--- a/packages/terminator-python/test_tree.py
+++ b/packages/terminator-python/test_tree.py
@@ -62,12 +62,8 @@ def test_get_window_tree():
 
         print(f"Testing with application: {app_name} (PID: {pid})")
 
-        # Create a custom config for fast tree building
-        property_mode = terminator.PropertyLoadingMode()
-        property_mode.mode = "Fast"  # Can be "Fast", "Complete", or "Smart"
-
         config = terminator.TreeBuildConfig()
-        config.property_mode = property_mode
+        config.property_mode = terminator.PropertyLoadingMode.fast() # Can be "fast", "complete", or "smart"
         config.timeout_per_operation_ms = 50
         config.yield_every_n_elements = 50
         config.batch_size = 50
@@ -88,11 +84,8 @@ def test_get_window_tree():
 
         # Test with different property modes
         print("\n--- Testing with Complete property mode ---")
-        complete_mode = terminator.PropertyLoadingMode()
-        complete_mode.mode = "Complete"
-
         complete_config = terminator.TreeBuildConfig()
-        complete_config.property_mode = complete_mode
+        complete_config.property_mode = terminator.PropertyLoadingMode.complete()
 
         complete_tree = desktop.get_window_tree(pid, None, complete_config)
         print(f"Total elements with Complete mode: {count_elements(complete_tree)}")


### PR DESCRIPTION
## Pull Request Template

### Description

Fixed the `test_tree.py` script. There was an issue with the binding of the `PropertyLoadingMode` types making the script unable to run. This patched fixed the issue by exporting relevant methods in `TreeBuildConfig`.

### Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

### AI Review & Code Quality
- [x] I asked AI to critique my PR and incorporated feedback
- [x] I formatted my code properly
- [x] I tested my changes locally

### Checklist
- [x] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [ ] Updated documentation if needed

### Additional Notes
Add any other context about the pull request here. 