### PR TITLE
feat(examples): add insurance PDF parser

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@ This directory contains example scripts demonstrating various capabilities of th
 | Gmail Automation | `gmail_automation.py` | Automates common tasks within the Gmail web interface |
 | **Project Examples** | | |
 | PDF to Form | `pdf-to-form/` | Converts PDF data into web forms using Terminator |
+| Insurance PDF Parser | `insurance-pdf-parser/` | Extracts fixed insurance claim PDF fields into JSON |
 | reCAPTCHA Resolver | `recaptcha-resolver/` | Automated reCAPTCHA solving |
 | AI Explorer | `ai-explorer/` | AI-powered UI exploration |
 | Next.js Workflows | `nextjs-workflows/` | Next.js integration examples |

--- a/examples/insurance-pdf-parser/README.md
+++ b/examples/insurance-pdf-parser/README.md
@@ -1,0 +1,58 @@
+# Insurance PDF Parser
+
+Example for the InsurancePDFParser bounty in issue #24.
+
+It parses a fixed insurance claim PDF into structured JSON. The example keeps the
+workflow intentionally deterministic so it can be used as a building block for a
+Terminator copilot flow:
+
+1. Read a claim PDF or already-extracted claim text.
+2. Extract a small fixed set of claim fields.
+3. Export normalized JSON for downstream UI automation.
+
+The included sample PDF is a tiny fixed-layout claim document generated as a
+plain PDF content stream. The parser also accepts `.txt` input so the extraction
+logic can be tested without a PDF renderer.
+
+## Fields
+
+- `claim_number`
+- `patient_name`
+- `service_date`
+- `provider`
+- `total_amount`
+- `currency`
+
+## Run
+
+From the repository root:
+
+```bash
+python examples/insurance-pdf-parser/insurance_pdf_parser.py \
+  examples/insurance-pdf-parser/sample_claim.pdf
+```
+
+Write JSON to a file:
+
+```bash
+python examples/insurance-pdf-parser/insurance_pdf_parser.py \
+  examples/insurance-pdf-parser/sample_claim.pdf \
+  --out examples/insurance-pdf-parser/sample_claim.output.json
+```
+
+Run the smoke test:
+
+```bash
+python examples/insurance-pdf-parser/insurance_pdf_parser.py \
+  examples/insurance-pdf-parser/sample_claim.pdf \
+  --expect examples/insurance-pdf-parser/expected_claim.json
+```
+
+## Why This Shape
+
+This example is meant to be a small copilot step, not a fully autonomous claims
+system. A human can review the extracted JSON before Terminator uses it to fill
+another desktop or web UI.
+
+For real claim templates, add field-specific regexes in `PATTERNS` and save a
+known-good expected JSON fixture for each supported layout.

--- a/examples/insurance-pdf-parser/expected_claim.json
+++ b/examples/insurance-pdf-parser/expected_claim.json
@@ -1,0 +1,8 @@
+{
+  "claim_number": "CLM-2026-0042",
+  "currency": "USD",
+  "patient_name": "Maya Patel",
+  "provider": "Northside Family Clinic",
+  "service_date": "2026-04-18",
+  "total_amount": 842.75
+}

--- a/examples/insurance-pdf-parser/insurance_pdf_parser.py
+++ b/examples/insurance-pdf-parser/insurance_pdf_parser.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Parse a fixed insurance claim PDF or text file into JSON.
+
+The PDF support is intentionally lightweight: it extracts literal strings from
+simple PDF content streams, which is enough for fixed-layout generated forms and
+keeps this example dependency-free.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+PATTERNS = {
+    "claim_number": [
+        r"\bclaim\s*(?:number|no\.?|#)\s*[:\-]\s*([A-Z0-9][A-Z0-9\-\/]+)",
+        r"\bclaim\s+([A-Z]{2,}-[0-9][A-Z0-9\-\/]+)",
+    ],
+    "patient_name": [
+        r"\bpatient\s*(?:name)?\s*[:\-]\s*([A-Z][A-Za-z ,.'-]+)",
+        r"\bmember\s*(?:name)?\s*[:\-]\s*([A-Z][A-Za-z ,.'-]+)",
+    ],
+    "service_date": [
+        r"\b(?:service|visit|claim)\s*date\s*[:\-]\s*([0-9]{4}-[0-9]{2}-[0-9]{2})",
+        r"\b(?:service|visit|claim)\s*date\s*[:\-]\s*([0-9]{1,2}[\/\-][0-9]{1,2}[\/\-][0-9]{2,4})",
+    ],
+    "provider": [
+        r"\bprovider\s*[:\-]\s*([A-Z][A-Za-z0-9 &.,'-]+)",
+        r"\bfacility\s*[:\-]\s*([A-Z][A-Za-z0-9 &.,'-]+)",
+    ],
+    "total_amount": [
+        r"\b(?:total|amount due|claim total|billed amount)\s*[:\-]?\s*\$?\s*([0-9,]+(?:\.[0-9]{2})?)",
+    ],
+}
+
+
+def decode_pdf_literal(raw: str) -> str:
+    """Decode a simple PDF literal string."""
+    replacements = {
+        r"\(": "(",
+        r"\)": ")",
+        r"\\": "\\",
+        r"\n": "\n",
+        r"\r": "\r",
+        r"\t": "\t",
+    }
+    value = raw
+    for old, new in replacements.items():
+        value = value.replace(old, new)
+    return value
+
+
+def extract_text_from_pdf_bytes(data: bytes) -> str:
+    """Extract text from simple PDF literal-string drawing operators."""
+    source = data.decode("latin-1", errors="ignore")
+    literal_pattern = re.compile(r"\((?:\\.|[^\\()])*\)\s*Tj")
+    array_pattern = re.compile(r"\[((?:\s*\((?:\\.|[^\\()])*\)\s*-?\d*)+)\]\s*TJ")
+    chunks: list[str] = []
+
+    for match in literal_pattern.finditer(source):
+        literal = match.group(0).rsplit(")", 1)[0][1:]
+        chunks.append(decode_pdf_literal(literal))
+
+    for match in array_pattern.finditer(source):
+        for literal in re.findall(r"\((?:\\.|[^\\()])*\)", match.group(1)):
+            chunks.append(decode_pdf_literal(literal[1:-1]))
+
+    if chunks:
+        return "\n".join(chunks)
+    return source
+
+
+def read_input(path: Path) -> str:
+    data = path.read_bytes()
+    if data.startswith(b"%PDF"):
+        return extract_text_from_pdf_bytes(data)
+    return data.decode("utf-8", errors="replace")
+
+
+def clean_value(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip(" .,\t\r\n")
+
+
+def first_match(text: str, patterns: list[str]) -> str | None:
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE | re.MULTILINE)
+        if match:
+            return clean_value(match.group(1))
+    return None
+
+
+def parse_amount(value: str | None) -> float | None:
+    if not value:
+        return None
+    try:
+        return float(value.replace(",", ""))
+    except ValueError:
+        return None
+
+
+def extract_claim(text: str) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for field, patterns in PATTERNS.items():
+        result[field] = first_match(text, patterns)
+
+    result["total_amount"] = parse_amount(result.get("total_amount"))
+    result["currency"] = "USD" if "$" in text or result.get("total_amount") is not None else None
+    return {key: value for key, value in result.items() if value not in (None, "")}
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Extract fixed claim PDF fields into JSON.")
+    parser.add_argument("input", type=Path, help="PDF or text file to parse.")
+    parser.add_argument("--out", type=Path, help="Optional path to write JSON output.")
+    parser.add_argument("--expect", type=Path, help="Optional expected JSON for smoke testing.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    result = extract_claim(read_input(args.input))
+    output = json.dumps(result, indent=2, sort_keys=True)
+
+    if args.out:
+        args.out.write_text(output + "\n", encoding="utf-8")
+    else:
+        print(output)
+
+    if args.expect:
+        expected = json.loads(args.expect.read_text(encoding="utf-8"))
+        if result != expected:
+            print("Parsed JSON did not match expected fixture.", file=sys.stderr)
+            print("Expected:", json.dumps(expected, indent=2, sort_keys=True), file=sys.stderr)
+            print("Actual:", output, file=sys.stderr)
+            return 1
+        print("Smoke test passed.", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/examples/insurance-pdf-parser/sample_claim.pdf
+++ b/examples/insurance-pdf-parser/sample_claim.pdf
@@ -1,0 +1,46 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 332 >>
+stream
+BT
+/F1 14 Tf
+72 720 Td
+(Insurance Claim Summary) Tj
+0 -28 Td
+(Claim Number: CLM-2026-0042) Tj
+0 -22 Td
+(Patient Name: Maya Patel) Tj
+0 -22 Td
+(Service Date: 2026-04-18) Tj
+0 -22 Td
+(Provider: Northside Family Clinic) Tj
+0 -22 Td
+(Billed Amount: $842.75) Tj
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000311 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+694
+%%EOF

--- a/examples/insurance-pdf-parser/sample_claim.txt
+++ b/examples/insurance-pdf-parser/sample_claim.txt
@@ -1,0 +1,5 @@
+Claim Number: CLM-2026-0042
+Patient Name: Maya Patel
+Service Date: 2026-04-18
+Provider: Northside Family Clinic
+Billed Amount: $842.75


### PR DESCRIPTION
## Summary

Adds an `insurance-pdf-parser` project example for the InsurancePDFParser bounty in issue #24.

The example parses a fixed insurance claim PDF into structured JSON and includes:

- dependency-free parser script
- fixed sample claim PDF
- text fallback fixture
- expected JSON fixture
- README with run and smoke-test commands
- examples README entry

## Why

This is designed as a small copilot-friendly step:

1. read a claim PDF or extracted text
2. extract fixed claim fields
3. let a human review JSON
4. hand the JSON to a later Terminator UI automation step

## Verification

```bash
python examples/insurance-pdf-parser/insurance_pdf_parser.py \
  examples/insurance-pdf-parser/sample_claim.pdf

python examples/insurance-pdf-parser/insurance_pdf_parser.py \
  examples/insurance-pdf-parser/sample_claim.pdf \
  --expect examples/insurance-pdf-parser/expected_claim.json
The smoke test prints:

Smoke test passed.