### PR TITLE
fix(mcp-agent): correct modifier key-combo normalization (Error Input Format) + cap UI-tree recursion depth

### DIFF
--- a/crates/terminator-mcp-agent/src/helpers.rs
+++ b/crates/terminator-mcp-agent/src/helpers.rs
@@ -9,12 +9,75 @@ use std::collections::HashMap;
 use std::time::Duration;
 use terminator::{AutomationError, Desktop, Selector, UIElement};
 
-/// Normalize key format to ensure curly brace syntax for special keys.
-/// If key already contains `{`, assume it's correctly formatted.
-/// Otherwise, wrap the entire key in `{}` to ensure it's treated as a special key press.
-/// Examples: "Enter" -> "{Enter}", "{Ctrl}c" -> "{Ctrl}c" (unchanged)
+/// Normalize a key string into valid `uiautomation` `send_keys` syntax.
+///
+/// Background: the underlying `uiautomation` keyboard grammar uses `{...}` for
+/// *named* keys / modifiers and groups chord characters with `(...)` after a
+/// modifier (e.g. `{Ctrl}(AB)` = Ctrl+A+B). A bare letter after a modifier is
+/// also held (`{Ctrl}c` = Ctrl+C). Crucially, a single letter inside braces such
+/// as `{Z}` is NOT a valid named key and the platform rejects it with
+/// `E_INVALIDARG` ("Error Input Format"). The previous implementation turned the
+/// documented `"Ctrl+Z"` into `"{Ctrl+Z}"` (one unknown token) — so every
+/// modifier combo failed. See [[terminator-mcp]].
+///
+/// Rules:
+/// - Already contains `{` → assume raw uiautomation syntax, pass through untouched
+///   (e.g. `"{Enter}"`, `"{Ctrl}a"`, `"{Ctrl}(AB)"`).
+/// - Contains `+` → treat as a combo: every part but the last is a modifier
+///   (`{Ctrl}`/`{Alt}`/`{Shift}`/`{Win}`); the final part is a literal char if a
+///   single character, else a braced named key.
+///   `"Ctrl+Z"` -> `"{Ctrl}z"`, `"Ctrl+Shift+S"` -> `"{Ctrl}{Shift}s"`,
+///   `"Alt+F4"` -> `"{Alt}{F4}"`.
+/// - A lone single character → literal keypress (`"a"` -> `"a"`).
+/// - Any other bare token → braced named key (`"Enter"` -> `"{Enter}"`).
 pub fn normalize_key(key: &str) -> String {
+    // Raw uiautomation syntax — trust it.
     if key.contains('{') {
+        return key.to_string();
+    }
+
+    fn modifier(m: &str) -> String {
+        match m.to_lowercase().as_str() {
+            "ctrl" | "control" | "ctl" => "{Ctrl}".to_string(),
+            "alt" | "menu" => "{Alt}".to_string(),
+            "shift" => "{Shift}".to_string(),
+            "win" | "windows" | "meta" | "cmd" | "command" | "super" => "{Win}".to_string(),
+            other => format!("{{{}}}", other), // unknown modifier: best effort
+        }
+    }
+    fn final_key(k: &str) -> String {
+        if k.chars().count() == 1 {
+            // Letter/digit/symbol held under the preceding modifier — literal char.
+            k.to_lowercase()
+        } else {
+            // Named key (F4, Tab, Left, Enter, …) — braced.
+            format!("{{{}}}", k)
+        }
+    }
+
+    // "+"-style combo, e.g. "Ctrl+Z", "Ctrl+Shift+S", "Alt+F4".
+    if key.contains('+') {
+        let parts: Vec<&str> = key
+            .split('+')
+            .map(|p| p.trim())
+            .filter(|p| !p.is_empty())
+            .collect();
+        if parts.len() >= 2 {
+            let last = parts.len() - 1;
+            let mut out = String::new();
+            for (i, part) in parts.iter().enumerate() {
+                if i < last {
+                    out.push_str(&modifier(part));
+                } else {
+                    out.push_str(&final_key(part));
+                }
+            }
+            return out;
+        }
+    }
+
+    // Single token.
+    if key.chars().count() == 1 {
         key.to_string()
     } else {
         format!("{{{}}}", key)
@@ -934,6 +997,33 @@ pub async fn verify_post_action(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_normalize_key_modifier_combos() {
+        // `+`-style combos (the LLM-facing format) must become valid uiautomation
+        // syntax: modifiers as {Mod}, a final LETTER/DIGIT as a literal char (NOT
+        // braced — {Z} is not a valid named key and errors with E_INVALIDARG),
+        // a final NAMED key braced.
+        assert_eq!(normalize_key("Ctrl+Z"), "{Ctrl}z");
+        assert_eq!(normalize_key("ctrl+c"), "{Ctrl}c");
+        assert_eq!(normalize_key("Ctrl+Shift+S"), "{Ctrl}{Shift}s");
+        assert_eq!(normalize_key("Win+Shift+S"), "{Win}{Shift}s");
+        assert_eq!(normalize_key("Alt+F4"), "{Alt}{F4}");
+        assert_eq!(normalize_key("Ctrl+Shift+Tab"), "{Ctrl}{Shift}{Tab}");
+        assert_eq!(normalize_key("Alt+Left"), "{Alt}{Left}");
+    }
+
+    #[test]
+    fn test_normalize_key_single_and_passthrough() {
+        // Bare named key -> braced (unchanged behaviour).
+        assert_eq!(normalize_key("Enter"), "{Enter}");
+        // Already-formatted uiautomation strings pass through untouched.
+        assert_eq!(normalize_key("{Enter}"), "{Enter}");
+        assert_eq!(normalize_key("{Ctrl}a"), "{Ctrl}a");
+        assert_eq!(normalize_key("{Ctrl}(AB)"), "{Ctrl}(AB)");
+        // A lone single character is a literal keypress, not a (invalid) {a}.
+        assert_eq!(normalize_key("a"), "a");
+    }
 
     #[test]
     fn test_substitute_simple_string_variable() {

--- a/crates/terminator-mcp-agent/src/utils.rs
+++ b/crates/terminator-mcp-agent/src/utils.rs
@@ -887,7 +887,7 @@ pub struct TypeIntoElementArgs {
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct PressKeyArgs {
     #[schemars(
-        description = "The key or key combination to press. Auto-normalized to curly brace format (e.g., 'Enter' -> '{Enter}'). Examples: 'Enter', 'Tab', 'Escape', 'Ctrl+A', '{Ctrl}c', '{Alt}{F4}'"
+        description = "The key or key combination to press. Use '+' for combos: 'Ctrl+Z', 'Ctrl+Shift+S', 'Alt+F4' (normalized to valid uiautomation syntax). Single keys: 'Enter', 'Tab', 'Escape', 'a'. Raw uiautomation syntax also accepted: '{Ctrl}z', '{Alt}{F4}', '{Ctrl}(AB)'. Do NOT brace a single letter as a named key ('{Z}' is invalid — use 'Ctrl+Z' or '{Ctrl}z')."
     )]
     pub key: String,
     #[schemars(
@@ -929,7 +929,7 @@ pub struct GlobalKeyArgs {
     pub process: String,
 
     #[schemars(
-        description = "The key or key combination to press. Auto-normalized to curly brace format (e.g., 'Enter' -> '{Enter}'). Examples: 'Enter', 'PageDown', 'Ctrl+V', '{Ctrl}{V}'"
+        description = "The key or key combination to press. Use '+' for combos: 'Ctrl+V', 'Ctrl+Shift+S', 'Alt+F4' (normalized to valid uiautomation syntax). Single keys: 'Enter', 'PageDown', 'a'. Raw uiautomation syntax also accepted: '{Ctrl}v', '{Alt}{F4}', '{Ctrl}(AB)'. Do NOT brace a single letter as a named key ('{V}' is invalid — use 'Ctrl+V' or '{Ctrl}v')."
     )]
     pub key: String,
 

--- a/crates/terminator/src/platforms/windows/tree_builder.rs
+++ b/crates/terminator/src/platforms/windows/tree_builder.rs
@@ -380,6 +380,23 @@ pub(crate) fn get_element_children_with_timeout(
     }
 }
 
+/// Hard cap on UI-tree recursion depth.
+///
+/// `build_node_from_cached_element` walks the cached tree recursively. On
+/// pathologically deep trees (some Win32/WPF apps nest hundreds of levels) this
+/// has overflowed the native stack — Windows terminates the process with exit
+/// code `0xC00000FD`, which the npm wrapper detects and restarts. We bound the
+/// depth even when the caller passes no `max_depth`, so a single deep window can
+/// never crash the server. 50 is comfortably above realistic UI nesting (the MCP
+/// default tree depth is 30).
+pub(crate) const SAFE_MAX_TREE_DEPTH: usize = 50;
+
+/// Clamp an optional caller-supplied max depth to [`SAFE_MAX_TREE_DEPTH`].
+/// `None` (no limit requested) becomes the cap; any larger value is capped.
+pub(crate) fn cap_tree_depth(requested: Option<usize>) -> usize {
+    requested.unwrap_or(SAFE_MAX_TREE_DEPTH).min(SAFE_MAX_TREE_DEPTH)
+}
+
 /// Build a UI node tree using UIA caching for dramatically improved performance.
 /// This uses a single IPC call to fetch all elements with their properties pre-loaded,
 /// instead of making ~15 IPC calls per element.
@@ -444,12 +461,14 @@ pub(crate) fn build_tree_with_cache(
         cache_build_time
     );
 
-    // Build tree recursively using CACHED data (no more IPC calls)
+    // Build tree recursively using CACHED data (no more IPC calls).
+    // Clamp depth to a hard cap so a pathologically deep tree can't overflow the
+    // native stack (see SAFE_MAX_TREE_DEPTH).
     let mut elements_count = 0;
     let result = build_node_from_cached_element(
         &cached_root,
         0,
-        max_depth,
+        Some(cap_tree_depth(max_depth)),
         &application_name,
         include_all_bounds,
         &mut elements_count,
@@ -581,4 +600,23 @@ fn build_node_from_cached_element(
     }
 
     Ok(node)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cap_tree_depth() {
+        // No explicit limit → cap applies (prevents unbounded recursion).
+        assert_eq!(cap_tree_depth(None), SAFE_MAX_TREE_DEPTH);
+        // A modest request is honoured as-is.
+        assert_eq!(cap_tree_depth(Some(10)), 10);
+        // An excessive request is clamped down.
+        assert_eq!(cap_tree_depth(Some(1000)), SAFE_MAX_TREE_DEPTH);
+        // Exactly at the cap stays at the cap.
+        assert_eq!(cap_tree_depth(Some(SAFE_MAX_TREE_DEPTH)), SAFE_MAX_TREE_DEPTH);
+        // Zero is a valid (root-only) request.
+        assert_eq!(cap_tree_depth(Some(0)), 0);
+    }
 }


### PR DESCRIPTION
## Summary

Two independent fixes for the Windows MCP agent:

1. **Modifier key-combos were broken in `press_key` / `press_key_global`.**
2. **The cached UI-tree walk can overflow the stack on deeply-nested windows.**

---

### 1. Key-combo normalization (`crates/terminator-mcp-agent/src/helpers.rs`)

`normalize_key` wrapped the entire key string in braces when it didn't already
contain `{`, so the documented `"Ctrl+Z"` became `"{Ctrl+Z}"` — a single unknown
token that the `uiautomation` backend rejects:

```
-32002 "Failed to press key on focused element"
Platform-specific error: Error { code: 6, message: "Error Input Format" }
```

Every modifier combo (`Ctrl+Z`, `Ctrl+A`, `Alt+F4`, …) failed. The schema
docstrings also recommended a broken form (`"{Ctrl}{V}"`): a single **letter**
inside braces (`{V}`) is not a valid named key.

**Fix:** parse `+`-separated combos into valid `uiautomation` syntax —
modifiers → `{Ctrl}`/`{Alt}`/`{Shift}`/`{Win}`; a final single character → a
literal char held under the modifier (`"{Ctrl}z"`); a final named key → braced
(`"{Alt}{F4}"`). Already-braced raw syntax and lone characters pass through
unchanged. This matches the behaviour of the existing, tested
`translate_gemini_keys` converter in `terminator-computer-use`.

Also corrects the misleading `key` docstrings for `PressKeyArgs` /
`GlobalKeyArgs` (`src/utils.rs`).

| input | before | after |
|---|---|---|
| `Ctrl+Z` | `{Ctrl+Z}` ❌ | `{Ctrl}z` ✅ |
| `Ctrl+Shift+S` | `{Ctrl+Shift+S}` ❌ | `{Ctrl}{Shift}s` ✅ |
| `Alt+F4` | `{Alt+F4}` ❌ | `{Alt}{F4}` ✅ |

### 2. UI-tree depth cap (`crates/terminator/src/platforms/windows/tree_builder.rs`)

`build_node_from_cached_element` recurses unbounded when the caller passes no
`tree_max_depth`. Deeply-nested windows overflow the native stack — Windows
terminates the process with `0xC00000FD` (the exit code the npm wrapper already
special-cases and restarts on). Add `cap_tree_depth()` / `SAFE_MAX_TREE_DEPTH`
(50) and apply it in `build_tree_with_cache` so the cached walk is always
bounded, even with no explicit depth.

---

## Testing

- Unit tests added for `normalize_key` (combos, single keys, passthrough) and
  `cap_tree_depth`. Verified red→green (breaking the fix fails the test).
- `cargo test -p terminator-mcp-agent --lib` / `-p terminator-rs --lib` pass.
- **Empirical runtime check** against a release build: `press_key_global` with
  `Ctrl+N` / `Ctrl+A` / `Ctrl+W` now return `executed_without_error`
  (`key_pressed: "{Ctrl}n"` etc.) where the previous build returned
  `Error Input Format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
