### PR TITLE
Harden and extend the Terminator Python examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,44 +1,108 @@
 # Terminator Examples
 
-This directory contains example scripts demonstrating various capabilities of the Terminator automation framework.
+This directory contains example scripts demonstrating the [Terminator](https://github.com/mediar-ai/terminator) desktop-automation framework. Each script drives a real application (Calculator, Notepad, VLC, Chrome, …) through Terminator's accessibility-based UI automation — finding elements by role/name/AutomationId, clicking, typing, capturing screenshots, and running OCR.
 
-## Examples Table
+## Prerequisites
 
-| Example | Path | Description |
-|---------|------|-------------|
-| **Python - Windows Applications** | | |
-| Windows Calculator | `win_calculator.py` | Automates Windows Calculator with arithmetic operations |
-| Notepad Automation | `notepad.py` | Automates basic interactions with Windows Notepad |
-| MS Paint Automation | `mspaint.py` | Automates drawing shapes and saving images in MS Paint |
-| Snipping Tool | `snipping_tool.py` | Automates the Windows Snipping Tool for screenshots |
-| **Python - Cross-Platform** | | |
-| Monitor Example | `monitor_example.py` | Retrieves monitor information for windows and UI elements |
-| Element Screenshot | `element_screenshot.py` | Captures screenshots of UI elements and performs OCR |
-| VLC Auto Player | `vlc_auto_player.py` | Controls VLC media player to automatically play media |
-| **Python - Platform-Specific** | | |
-| GNOME Calculator | `gnome-calculator.py` | Demonstrates automation of GNOME Calculator on Linux |
-| macOS Calculator | `macos_calculator.py` | Demonstrates automation of Calculator on macOS |
-| **Python - Web Automation** | | |
-| Gmail Automation | `gmail_automation.py` | Automates common tasks within the Gmail web interface |
-| **Project Examples** | | |
-| PDF to Form | `pdf-to-form/` | Converts PDF data into web forms using Terminator |
-| reCAPTCHA Resolver | `recaptcha-resolver/` | Automated reCAPTCHA solving |
-| AI Explorer | `ai-explorer/` | AI-powered UI exploration |
-| Next.js Workflows | `nextjs-workflows/` | Next.js integration examples |
+- **Python 3.9+**
+- The `terminator.py` package:
+  ```bash
+  pip install terminator.py
+  ```
+- **Pillow** (only needed for the screenshot/OCR examples — `element_screenshot.py`, `gmail_automation.py`):
+  ```bash
+  pip install Pillow
+  ```
+- **VLC** must be installed for `vlc_auto_player.py`. Streaming a YouTube link additionally needs:
+  ```bash
+  pip install yt-dlp        # resolves the page URL to a direct stream
+  winget install Gyan.FFmpeg   # trims + re-streams the clip over HTTP
+  ```
+- **Google Chrome** for `gmail_automation.py`.
 
-## Platform Compatibility
+Most scripts open a real window and take over the mouse/keyboard while they run, so let them finish before touching the machine.
 
-| Example Type | Windows | Linux | macOS |
-|--------------|---------|-------|-------|
-| Windows Apps (notepad, mspaint, etc.) | ✓ | ✗ | ✗ |
+## Running the examples
+
+Run any single example directly:
+
+```bash
+python examples/win_calculator.py
+python examples/vlc_auto_player.py --youtube-link "https://www.youtube.com/watch?v=YQHsXMglC9A"
+python examples/vlc_auto_player.py --file "my_video.mp4"
+```
+
+### Run them all
+
+Two convenience runners execute every example in this directory (skipping the
+other-OS demos `gnome-*`/`macos-*` and the `_*`-prefixed scratch scripts, and
+running `vlc_auto_player.py` last because it streams for a while):
+
+```bash
+# Windows (PowerShell) — passes a default YouTube link to the VLC example
+./examples/run_all.ps1
+
+# Git Bash / Linux / macOS
+./examples/run_all.sh
+```
+
+Both runners prefer a project virtualenv at `.venv/` if one exists, otherwise
+they fall back to `python` on `PATH`.
+
+## What each example does
+
+### Windows applications
+
+| Example | What it does |
+|---------|--------------|
+| [win_calculator.py](win_calculator.py) | Opens the Windows Calculator (by AppUserModelID) and computes `1 + 2`, reading the result back from the display. Uses `nativeid:` (AutomationId) selectors so `1`/`2` aren't confused with Scientific-mode exponent buttons. |
+| [notepad.py](notepad.py) | Opens Notepad, highlights UI elements, and types text (handles both Windows 11 and the classic Notepad). |
+| [mspaint.py](mspaint.py) | Opens MS Paint, selects shapes/tools, draws on the canvas, and saves the image. |
+| [snipping_tool.py](snipping_tool.py) | Drives the Windows Snipping Tool: selects a snip mode, starts a new full-screen screenshot, and moves the mouse in a near-circle while the button is held. |
+
+### Cross-platform
+
+| Example | What it does |
+|---------|--------------|
+| [monitor_example.py](monitor_example.py) | Enumerates open windows and prints the monitor (name, id, geometry) each one lives on. |
+| [element_screenshot.py](element_screenshot.py) | Launches Notepad, types multi-line text, captures a screenshot of the editor body, frames it with a border, saves `screenshot.png`, and runs OCR to read the text back. |
+| [vlc_auto_player.py](vlc_auto_player.py) | Automates VLC to play a local file (`--file`) or a network/YouTube stream (`--youtube-link`). For YouTube it resolves the direct URL with yt-dlp and re-streams the first minute over local HTTP with ffmpeg (VLC's built-in YouTube extractor is unreliable). |
+
+### Web automation
+
+| Example | What it does |
+|---------|--------------|
+| [gmail_automation.py](gmail_automation.py) | Launches Chrome with a **dedicated automation profile** (`--user-data-dir` + `--force-renderer-accessibility`), opens Gmail, composes and sends an email, then opens it from the Sent folder — saving a numbered screenshot at each step. Edit the `recipient`/`subject`/`body` in `main()` before running; sign in once in the automation-profile window and it stays signed in. |
+
+### Platform-specific (non-Windows)
+
+| Example | What it does |
+|---------|--------------|
+| [gnome-calculator.py](gnome-calculator.py) | Automates the GNOME Calculator on Linux (adjusts selectors by detected version). |
+| [macos_calculator.py](macos_calculator.py) | Automates the Calculator app on macOS. |
+
+### Scratch / diagnostic scripts
+
+`_`-prefixed files are ad-hoc diagnostics, not polished demos, and are skipped by the `run_all` scripts:
+
+| File | What it does |
+|------|--------------|
+| [_diag_vlc.py](_diag_vlc.py) | Probes whether VLC's `Ctrl+N` (Open Media) dialog appears with and without activating the window first — used to debug focus/activation behavior. |
+
+## Platform compatibility
+
+| Example type | Windows | Linux | macOS |
+|--------------|:-------:|:-----:|:-----:|
+| Windows apps (calculator, notepad, mspaint, snipping tool) | ✓ | ✗ | ✗ |
 | GNOME Calculator | ✗ | ✓ | ✗ |
 | macOS Calculator | ✗ | ✗ | ✓ |
-| Web Automation | ✓ | ✓ | ✓ |
-| Monitor/Screenshot | ✓ | ✓ | ✓ |
+| Web automation (Gmail) | ✓ | ✓ | ✓ |
+| Monitor / screenshot / OCR | ✓ | ✓ | ✓ |
 
 ## Troubleshooting
 
-1. **"Application not found"** - Ensure the target application is installed
-2. **"Element not found"** - UI selectors may vary between OS versions
-3. **"Module not found"** - Install required dependencies
-4. **Encoding errors** - Fixed for cross-platform compatibility 
+1. **"Application not found"** — Ensure the target application is installed and, on Windows, launchable by the identifier used in the script.
+2. **"Element not found"** — UI selectors vary between OS/app versions. Many scripts branch on Windows 10 vs 11; adjust `role:`/`name:`/`nativeid:` selectors if your version differs.
+3. **"Module not found"** — Install the dependency listed under [Prerequisites](#prerequisites) (`terminator.py`, `Pillow`, `yt-dlp`).
+4. **Gmail shows a blank/empty page to automation** — Chrome must be launched with `--force-renderer-accessibility` (the example does this automatically); a normal Chrome window won't expose page content to the accessibility tree.
+5. **VLC won't play a YouTube link** — Install `yt-dlp` and `ffmpeg`; VLC's bundled extractor can no longer decipher YouTube stream signatures on its own.

--- a/examples/element_screenshot.py
+++ b/examples/element_screenshot.py
@@ -1,45 +1,129 @@
 """
 Element Screenshot Example
 
-This example demonstrates capturing screenshots of UI elements and performing OCR.
+Launches Notepad, types several lines of text, then captures a screenshot of the
+editor body, frames it with a border, and runs OCR on it -- a more interesting
+demo than grabbing the first anonymous button on the desktop. The editor body is
+large and high-contrast, so OCR reliably reads the text back.
 
 Requirements:
     pip install Pillow
 """
 
 import asyncio
+import os
+import platform
+import subprocess
+import sys
 try:
-    from PIL import Image
+    from PIL import Image, ImageOps
 except ImportError:
     print("Please install Pillow: pip install Pillow")
     exit(1)
 import terminator
 
+# Multi-line sample so the OCR result is interesting.
+SAMPLE_TEXT = (
+    "hello from terminator!\n"
+    "this is a python test.\n"
+    "the editor body is captured and OCR'd."
+)
+
+# Launch Notepad by its full path rather than the bare name "notepad". On some
+# machines "notepad(.exe)" is remapped to a third-party editor (e.g. Notepad++),
+# and open_application() would hand us that window instead.
+NOTEPAD_PATH = r"C:\Windows\System32\notepad.exe"
+
+# Bind to the freshly launched Notepad window by its title. open_application()
+# can return a sibling window handle that doesn't contain the editor, so we
+# locate the real one explicitly. "Untitled - Notepad" also avoids matching a
+# "... - Notepad++" window, which a bare "Notepad" substring would catch.
+NOTEPAD_WINDOW = "role:Window|name:contains:Untitled - Notepad"
+
+# Border drawn around the captured element (RGBA) and its thickness in pixels.
+BORDER_COLOR = (0, 255, 0, 255)  # green
+BORDER_WIDTH = 6
+
+
+def open_image(path):
+    """Open an image file in the OS default viewer (Windows/macOS/Linux)."""
+    path = os.path.abspath(path)
+    print(f"Opening {path} ...")
+    try:
+        if sys.platform.startswith("win"):
+            os.startfile(path)  # type: ignore[attr-defined]
+        elif sys.platform == "darwin":
+            subprocess.run(["open", path], check=False)
+        else:
+            subprocess.run(["xdg-open", path], check=False)
+    except Exception as e:
+        print(f"Could not open {path}: {e}")
+
+
+async def capture_editor_body(desktop: terminator.Desktop):
+    """Open Notepad, type text, and capture + OCR the editor body."""
+    print("Opening Notepad...")
+    desktop.open_application(NOTEPAD_PATH)
+    await asyncio.sleep(2.5)
+
+    window = await desktop.locator(NOTEPAD_WINDOW).timeout(15_000).first()
+
+    # The editable surface is a Document on Windows 11's Notepad and an Edit on the
+    # classic one. This is the element whose body we screenshot.
+    editor_role = "role:Document" if platform.release() == "11" else "role:Edit"
+    document = await window.locator(editor_role).timeout(10_000).first()
+    print(f"Found editor body: {document.name()!r}")
+    document.click()
+    document.type_text(SAMPLE_TEXT)
+    await asyncio.sleep(0.5)
+
+    # Highlight the element on screen with a border so it's obvious live which
+    # element we're capturing.
+    document.highlight(color=0x00FF00, duration_ms=2000)
+
+    print("Capturing screenshot of the editor body...\n")
+    screenshot = document.capture()
+    print(
+        f"Screenshot dimensions: {screenshot.width}x{screenshot.height}, "
+        f"data length: {len(screenshot.image_data)}\n"
+    )
+
+    print("Converting screenshot to PIL Image...")
+    image = Image.frombytes(
+        "RGBA", (screenshot.width, screenshot.height), screenshot.image_data
+    )
+    # Frame the captured element with a border so the saved image also clearly
+    # shows which element was screenshotted (the on-screen highlight isn't part of
+    # the element's own capture region).
+    image = ImageOps.expand(image, border=BORDER_WIDTH, fill=BORDER_COLOR)
+    print("Saving screenshot to screenshot.png\n")
+    screenshot_path = "screenshot.png"
+    image.save(screenshot_path)
+
+    print("Performing OCR on screenshot...")
+    text = await desktop.ocr_screenshot(screenshot)
+    ocr_result = text if text.strip() else "(no text recognized)"
+    print("OCR result:\n")
+    print(ocr_result)
+
+    # Write the OCR result back into the same editor body, below the original
+    # text and separated by a divider line so the two are clearly distinct.
+    print("\nWriting OCR result back into the editor body...")
+    document.click()
+    document.press_key("{Ctrl}{End}")  # move the cursor to the end of the text
+    document.type_text("\n================\n" + ocr_result)
+    await asyncio.sleep(0.5)
+
+    # Open the saved screenshot in the default image viewer so the result is
+    # shown as soon as the script finishes.
+    print()
+    open_image(screenshot_path)
+
 
 async def main():
-    desktop = terminator.Desktop()
-
-    locator = desktop.locator("role:Button")
+    desktop = terminator.Desktop(log_level="error")
     try:
-        window = await locator.first()
-        print("Capturing screenshot...\n")
-        screenshot = window.capture()
-        print(
-            f"Screenshot dimensions: {screenshot.width}x{screenshot.height}, data length: {len(screenshot.image_data)}\n"
-        )
-
-        print("Converting screenshot to PIL Image...")
-        image = Image.frombytes(
-            "RGBA", (screenshot.width, screenshot.height), screenshot.image_data
-        )
-        print("Saving screenshot to screenshot.png\n")
-        image.save("screenshot.png")
-
-        print("Performing OCR on screenshot...")
-        text = await desktop.ocr_screenshot(screenshot)
-        print("OCR result:\n")
-        print(text)
-
+        await capture_editor_body(desktop)
     except Exception as e:
         print("Error:", str(e))
 

--- a/examples/gmail_automation.py
+++ b/examples/gmail_automation.py
@@ -1,9 +1,145 @@
 import asyncio
+import itertools
+import os
+import shutil
+import subprocess
+import time
+
 import terminator
 import logging
 
+try:
+    from PIL import Image
+except ImportError:
+    Image = None
+
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+# Directory for step-by-step verification screenshots.
+SCREENSHOT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "screenshots")
+_step_counter = itertools.count(1)
+
+
+def save_screenshot(element: "terminator.UIElement", label: str) -> None:
+    """
+    Capture a screenshot of `element` and save it to SCREENSHOT_DIR.
+
+    Used to verify each automation step ran against the correct window. Never
+    raises -- a screenshot failure must not abort the automation.
+    """
+    if Image is None:
+        logging.warning("Pillow not installed; skipping screenshot '%s'.", label)
+        return
+    try:
+        os.makedirs(SCREENSHOT_DIR, exist_ok=True)
+        shot = element.capture()
+        img = Image.frombytes("RGBA", (shot.width, shot.height), shot.image_data)
+        n = next(_step_counter)
+        path = os.path.join(SCREENSHOT_DIR, f"{n:02d}_{label}.png")
+        img.save(path)
+        logging.info("Screenshot saved: %s", path)
+    except Exception as e:  # noqa: BLE001 - screenshots are best-effort
+        logging.warning("Could not capture screenshot '%s': %s", label, e)
+
+# Selector for the Chrome browser window. Chrome exposes its top-level window
+# as a *Pane* whose name is the tab title, e.g.
+#   "Inbox (12) - you@gmail.com - Gmail - Google Chrome"
+# We match on "Gmail - Google Chrome" (not just "Gmail") so it can't accidentally
+# bind to the VS Code window, whose title also contains "gmail" when this file is
+# open. `name:contains:` is a case-insensitive substring match.
+GMAIL_WINDOW = "role:Pane|name:contains:Gmail - Google Chrome"
+
+# How long to wait for the Gmail compose field to appear after Chrome launches.
+# This covers the whole sign-in flow, including typing a password AND entering an
+# authenticator-app 2FA token, so keep it generous. The script does not block for
+# the full duration -- it proceeds the moment the field is found.
+LOGIN_TIMEOUT_MS = 180_000  # 3 minutes
+
+# Timeout for UI elements once Gmail is already loaded (e.g. the compose fields).
+COMPOSE_TIMEOUT_MS = 30_000  # 30 seconds
+
+# Dedicated Chrome profile for automation. Launched with its own --user-data-dir so
+# it runs as a separate instance alongside your everyday browser (no need to close
+# your normal Chrome). It is also launched with `--force-renderer-accessibility`,
+# which is REQUIRED: without it Chrome does not expose web-page content to the OS
+# accessibility tree, so Terminator cannot see the Gmail fields. Sign into Gmail in
+# the window that opens on first run; the profile stays signed in for later runs.
+AUTOMATION_PROFILE = os.path.join(
+    os.path.expanduser("~"), ".terminator_chrome_profile"
+)
+
+
+def _find_chrome() -> str:
+    """Locate the Chrome executable on Windows."""
+    candidates = [
+        shutil.which("chrome"),
+        r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+        r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
+        os.path.expandvars(r"%LOCALAPPDATA%\Google\Chrome\Application\chrome.exe"),
+    ]
+    for path in candidates:
+        if path and os.path.exists(path):
+            return path
+    raise FileNotFoundError(
+        "Could not find chrome.exe. Set the path manually in _find_chrome()."
+    )
+
+
+def _close_automation_chrome() -> None:
+    """
+    Close only the Chrome processes that belong to AUTOMATION_PROFILE.
+
+    Repeated runs otherwise accumulate stale Gmail windows (old drafts, opened
+    emails), which makes the window selectors ambiguous. We filter by command line
+    so this NEVER touches your everyday Chrome -- only the automation profile.
+    """
+    profile_marker = os.path.basename(AUTOMATION_PROFILE)  # ".terminator_chrome_profile"
+    ps = (
+        "Get-CimInstance Win32_Process -Filter \"Name='chrome.exe'\" | "
+        f"Where-Object {{ $_.CommandLine -like '*{profile_marker}*' }} | "
+        "ForEach-Object { Stop-Process -Id $_.ProcessId -Force }"
+    )
+    subprocess.run(
+        ["powershell.exe", "-NoProfile", "-Command", ps],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def launch_gmail_chrome(url: str) -> None:
+    """
+    Launch Chrome with renderer accessibility forced on and open the given URL.
+
+    Uses a dedicated --user-data-dir (AUTOMATION_PROFILE) so it runs as its own
+    instance without disturbing your everyday Chrome. `--force-renderer-accessibility`
+    is the key flag: it makes Chrome publish the web page to the accessibility tree
+    so Terminator can find the Gmail fields.
+    """
+    chrome = _find_chrome()
+    # Start from a clean slate: close any leftover automation windows first so there
+    # is exactly one Gmail window and the selectors stay unambiguous.
+    _close_automation_chrome()
+    time.sleep(2)
+    logging.info("Launching Chrome (automation profile) with accessibility enabled...")
+    subprocess.Popen(
+        [
+            chrome,
+            "--force-renderer-accessibility",
+            f"--user-data-dir={AUTOMATION_PROFILE}",
+            "--no-first-run",
+            "--no-default-browser-check",
+            "--hide-crash-restore-bubble",  # suppress "Chrome didn't shut down correctly"
+            "--new-window",
+            # Start maximized so the whole Gmail UI (Compose + Send buttons) is on
+            # screen. Terminator can only click elements that are actually rendered;
+            # a small or partially off-screen window leaves those controls invisible
+            # and the automation fails. See also the maximize_window() call after the
+            # window is activated, which enforces this state at runtime.
+            "--start-maximized",
+            url,
+        ]
+    )
 
 
 async def open_gmail_compose(
@@ -19,74 +155,182 @@ async def open_gmail_compose(
         body: Body content of the email
     """
     try:
-        # Open Gmail in default browser
-        gmail_url = "https://mail.google.com/mail/u/0/#inbox?compose=new"
-        logging.info("Opening Gmail compose window...")
-        desktop.open_url(gmail_url)
+        # Open the Gmail inbox in a Chrome instance that exposes web accessibility.
+        # We do NOT use the "?compose=new" URL trick: on a fresh/first load it can
+        # open the compose dialog before the inbox is interactive (or not at all).
+        # Instead we wait for the inbox, then click the Compose button ourselves.
+        gmail_url = "https://mail.google.com/mail/u/0/#inbox"
+        logging.info("Opening Gmail...")
+        launch_gmail_chrome(gmail_url)
 
-        # Wait for the page to load
-        await asyncio.sleep(10)  # Adjust this based on your internet speed
+        # Scope all lookups to the Gmail browser window. We search descendants
+        # directly (Chrome nests the page content several Panes deep, so there is
+        # no reliable single "Document" node to chain through).
+        gmail_window = desktop.locator(GMAIL_WINDOW)
 
-        # Get the Gmail window
-        gmail_window = desktop.locator("window:Gmail")
-        document = gmail_window.locator("role:Document")
+        # Wait for the inbox to finish loading, keyed on the Compose button. This
+        # uses a long timeout so it tolerates the full sign-in flow (password AND
+        # authenticator 2FA token) plus the first-load of a large mailbox.
+        logging.info(
+            "Waiting up to %ds for Gmail to load "
+            "(complete sign-in and 2FA if prompted)...",
+            LOGIN_TIMEOUT_MS // 1000,
+        )
+        compose_button = (
+            await gmail_window.locator("name:Compose")
+            .timeout(LOGIN_TIMEOUT_MS)
+            .first()
+        )
 
-        # Find and fill recipient field
-        recipient_field = await document.locator("name:To recipients").first()
+        # Pin to the exact window that owns the Compose button. Your everyday Chrome
+        # may also have a "... - Gmail - Google Chrome" window, so GMAIL_WINDOW can
+        # match several; only the automation window exposes accessible web content
+        # (hence the Compose button). Scoping every later lookup to this element
+        # keeps us out of the wrong window. Bring it to the foreground too, because
+        # type_text/press_key go to whatever window currently has focus.
+        window_el = compose_button.window() or await gmail_window.first()
+        window_el.activate_window()
+        # Force the window into a known, fully-visible state. Terminator can only
+        # click controls that are actually rendered on screen, so if the window is
+        # small or partially off-screen the Compose/Send buttons are unreachable and
+        # the run fails. Maximizing (in addition to --start-maximized at launch)
+        # makes the window state reproducible regardless of how Chrome last closed.
+        try:
+            window_el.maximize_window()
+        except Exception as e:  # noqa: BLE001 - best-effort; continue if unsupported
+            logging.warning("Could not maximize the Gmail window: %s", e)
+        await asyncio.sleep(1)
+        save_screenshot(window_el, "gmail_loaded")
+
+        # Open the compose dialog and wait for the recipient field (a ComboBox
+        # named "To recipients").
+        logging.info("Opening compose window...")
+        compose_button.click()
+        recipient_field = (
+            await window_el.locator("role:ComboBox|name:To recipients")
+            .timeout(COMPOSE_TIMEOUT_MS)
+            .first()
+        )
+        save_screenshot(window_el, "compose_opened")
+
         recipient_field.highlight(color=0x00FF00, duration_ms=2000)  # Green highlight
+        recipient_field.click()  # ensure focus before typing
         recipient_field.type_text(recipient)
+        # Commit the recipient and dismiss the autocomplete dropdown, otherwise it
+        # can steal the keystrokes intended for the next field.
+        recipient_field.press_key("{Escape}")
         await asyncio.sleep(1)
+        save_screenshot(window_el, "recipient_filled")
 
-        # Find and fill subject field
-        subject_field = await document.locator("name:Subject").first()
+        # Find and fill subject field. We must pin the role to Edit: a bare
+        # "name:Subject" also matches inbox email rows whose preview text contains
+        # "Subject:", and .first() would grab one of those instead of the compose
+        # box -- which is exactly why the subject was landing in the wrong place.
+        subject_field = (
+            await window_el.locator("role:Edit|name:Subject")
+            .timeout(COMPOSE_TIMEOUT_MS)
+            .first()
+        )
         subject_field.highlight(color=0x0000FF, duration_ms=2000)  # Blue highlight
+        subject_field.click()  # focus the subject box before typing
+        await asyncio.sleep(0.3)
         subject_field.type_text(subject)
+        await asyncio.sleep(0.5)
+        # Verify the subject actually landed; warn loudly if not.
+        typed = (subject_field.text() or "").strip()
+        if subject not in typed:
+            logging.warning(
+                "Subject may not have been entered (field text=%r). Retrying...",
+                typed,
+            )
+            subject_field.click()
+            await asyncio.sleep(0.3)
+            subject_field.type_text(subject)
         await asyncio.sleep(1)
+        save_screenshot(window_el, "subject_filled")
 
         # Find and fill body field
-        body_field = await document.locator("name:Message Body").first()
+        body_field = (
+            await window_el.locator("role:Edit|name:Message Body")
+            .timeout(COMPOSE_TIMEOUT_MS)
+            .first()
+        )
         body_field.highlight(color=0xFF00FF, duration_ms=2000)  # Magenta highlight
+        body_field.click()  # focus the body before typing
+        await asyncio.sleep(0.3)
         body_field.type_text(body)
         await asyncio.sleep(1)
+        save_screenshot(window_el, "body_filled")
 
         logging.info("Email composed successfully!")
 
-        # Find and click the Send button
-        send_button = await document.locator("name:(Ctrl-Enter)").first()
+        # Find and click the Send button (labelled "Send \u202A(Ctrl-Enter)\u202C")
+        send_button = await window_el.locator("name:Ctrl-Enter").first()
         send_button.highlight(color=0xFFFF00, duration_ms=2000)  # Yellow highlight
         send_button.click()
-        await asyncio.sleep(1)
+        await asyncio.sleep(2)
+        save_screenshot(window_el, "email_sent")
 
         logging.info("Email sent successfully!")
 
         # Navigate to Sent folder
-        sent_button = await document.locator("name:Labels").locator("name:Sent").first()
+        sent_button = await window_el.locator("name:Sent").first()
         sent_button.highlight(color=0x00FFFF, duration_ms=2000)  # Cyan highlight
         sent_button.click()
         await asyncio.sleep(2)
+        save_screenshot(window_el, "sent_folder")
 
-        # Open the sent email
-        grid_item = (
-            await document.locator("role:DataGrid").locator("role:DataItem").first()
-        )
-        grid_item.highlight(color=0xFFA500, duration_ms=2000)  # Orange highlight
-        grid_item.click()
-
-        logging.info("Email opened successfully!")
+        # Open the sent email. Gmail's message list uses DataItem rows (there is no
+        # "DataGrid" role), so we locate the row by its body preview text. This is a
+        # verification convenience -- the email is already sent -- so a failure here
+        # is logged but does not fail the run.
+        try:
+            snippet = body[:25]
+            sent_item = (
+                await window_el.locator(f"role:DataItem|name:contains:{snippet}")
+                .timeout(COMPOSE_TIMEOUT_MS)
+                .first()
+            )
+            sent_item.highlight(color=0xFFA500, duration_ms=2000)  # Orange highlight
+            sent_item.click()
+            await asyncio.sleep(1)
+            save_screenshot(window_el, "email_opened")
+            logging.info("Email opened successfully!")
+        except Exception as e:  # noqa: BLE001 - opening the sent email is optional
+            logging.warning("Could not open the sent email (non-fatal): %s", e)
+            save_screenshot(window_el, "email_open_failed")
 
     except terminator.PlatformError as e:
         logging.error(f"Platform Error: {e}")
+        await _capture_failure(desktop)
         raise
     except Exception as e:
         logging.error(f"An unexpected error occurred: {e}")
+        await _capture_failure(desktop)
         raise
+
+
+async def _capture_failure(desktop: terminator.Desktop) -> None:
+    """Best-effort full-screen capture when a step fails, for debugging."""
+    if Image is None:
+        return
+    try:
+        monitor = await desktop.get_primary_monitor()
+        shot = await desktop.capture_monitor(monitor)
+        os.makedirs(SCREENSHOT_DIR, exist_ok=True)
+        img = Image.frombytes("RGBA", (shot.width, shot.height), shot.image_data)
+        path = os.path.join(SCREENSHOT_DIR, "99_FAILURE.png")
+        img.save(path)
+        logging.info("Failure screenshot saved: %s", path)
+    except Exception as e:  # noqa: BLE001
+        logging.warning("Could not capture failure screenshot: %s", e)
 
 
 async def main():
     desktop = terminator.Desktop(log_level="error")  # Suppress info logs
 
     # Email details
-    recipient = "ansh@gmail.com"  # Replace with actual recipient
+    recipient = "your_email@gmail.com"  # Replace with actual recipient
     subject = "Le Terminator est immortel."
     body = "This is a test email sent using Terminator automation."
 

--- a/examples/run_all.ps1
+++ b/examples/run_all.ps1
@@ -1,0 +1,38 @@
+# Run all Python scripts in this directory except gnome* and macos* ones.
+
+Set-Location -Path $PSScriptRoot
+
+# Prefer the project venv's Python if available.
+if (Test-Path ".venv\Scripts\python.exe") {
+    $Python = ".venv\Scripts\python.exe"
+} elseif (Test-Path ".venv\bin\python") {
+    $Python = ".venv\bin\python"
+} else {
+    $Python = "python"
+}
+
+# Per-script command line arguments. Scripts not listed here run with no args.
+# The URL is kept as a single quoted string so the '&' characters are passed
+# through literally instead of being treated as PowerShell operators.
+$ScriptArgs = @{
+    "vlc_auto_player.py" = @(
+        "--youtube-link",
+        "https://www.youtube.com/watch?v=YQHsXMglC9A&list=RDYQHsXMglC9A&start_radio=1"
+    )
+}
+
+Get-ChildItem -Path . -Filter *.py |
+    # Skip gnome*/macos* (other-OS demos) and _*-prefixed scratch/diagnostic
+    # scripts like _diag_vlc.py, which also opens VLC and would otherwise launch
+    # a second VLC window at the start of the run.
+    Where-Object { $_.Name -notlike "gnome*" -and $_.Name -notlike "macos*" -and $_.Name -notlike "_*" } |
+    # Keep the default alphabetical order, but force vlc_auto_player.py to run
+    # last (it opens VLC and streams for a while, so it's nicest at the end).
+    Sort-Object @{ Expression = { $_.Name -eq "vlc_auto_player.py" } }, Name |
+    ForEach-Object {
+        $extraArgs = $ScriptArgs[$_.Name]
+        Write-Host "=== Running $($_.Name) ==="
+        & $Python $_.Name @extraArgs
+        Write-Host "=== Finished $($_.Name) (exit $LASTEXITCODE) ==="
+        Write-Host ""
+    }

--- a/examples/run_all.sh
+++ b/examples/run_all.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Run all Python scripts in this directory except gnome* and macos* ones.
+set -u
+
+cd "$(dirname "$0")"
+
+# Prefer the project venv's Python if available.
+if [ -x ".venv/Scripts/python.exe" ]; then
+    PYTHON=".venv/Scripts/python.exe"
+elif [ -x ".venv/bin/python" ]; then
+    PYTHON=".venv/bin/python"
+else
+    PYTHON="python"
+fi
+
+run_script() {
+    echo "=== Running $1 ==="
+    "$PYTHON" "$1"
+    echo "=== Finished $1 (exit $?) ==="
+    echo
+}
+
+# Run everything except vlc_auto_player.py first...
+for script in *.py; do
+    # Skip other-OS demos, _*-prefixed scratch/diagnostic scripts (e.g.
+    # _diag_vlc.py, which also opens VLC), and vlc_auto_player.py (run last).
+    case "$script" in
+        gnome*|macos*|_*|vlc_auto_player.py) continue ;;
+    esac
+    run_script "$script"
+done
+
+# ...then run vlc_auto_player.py last (it opens VLC and streams for a while).
+if [ -f vlc_auto_player.py ]; then
+    run_script vlc_auto_player.py
+fi

--- a/examples/snipping_tool.py
+++ b/examples/snipping_tool.py
@@ -31,7 +31,7 @@ class SnipMode(Enum):
 async def select_snip_mode(app_window: terminator.Locator, mode: SnipMode):
     print(f"Selecting snip mode: {mode.value}")
     if is_windows_11():
-        button = await app_window.locator("ComboBox:Snipping Mode").first()
+        button = await app_window.locator("ComboBox:Snipping Area Dropdown Menu").first()
         options = button.list_options()
         for option in options:
             if option == mode.value:
@@ -92,6 +92,10 @@ async def run_snipping_tool():
                 "Name:New screenshot"
             ).first()
             new_screenshot_button.click()
+            # Wait for the full-screen capture overlay to become active before
+            # pressing the mouse; otherwise the initial mouse_click_and_hold is
+            # lost and the circular movement runs without the button held.
+            await asyncio.sleep(1)
 
         N = 100  # Number of sides for a near-circle
         screen: terminator.UIElement = await app_window.first()

--- a/examples/vlc_auto_player.py
+++ b/examples/vlc_auto_player.py
@@ -16,7 +16,138 @@ To play a local video file:
 """
 
 import asyncio
+import glob
+import os
+import shutil
+import subprocess
+import sys
+
 import terminator
+
+
+def find_ffmpeg():
+    """
+    Return the directory containing ffmpeg, or None if it can't be found.
+
+    We don't rely on ffmpeg being on PATH: an editor/terminal launched before
+    ffmpeg was installed keeps a stale PATH, so `ffmpeg` may be missing from the
+    process environment even though it's installed system-wide. We check PATH
+    first, then fall back to winget's standard install locations. The directory
+    is passed to yt-dlp via --ffmpeg-location so trimming works regardless.
+    """
+    on_path = shutil.which("ffmpeg")
+    if on_path:
+        return os.path.dirname(on_path)
+
+    local = os.environ.get("LOCALAPPDATA", "")
+    candidates = [
+        # winget shim directory (symlinks to the real binaries).
+        os.path.join(local, "Microsoft", "WinGet", "Links", "ffmpeg.exe"),
+        # winget package payload, e.g. Gyan.FFmpeg .../ffmpeg-*/bin/ffmpeg.exe.
+        *glob.glob(
+            os.path.join(
+                local, "Microsoft", "WinGet", "Packages",
+                "*FFmpeg*", "ffmpeg-*", "bin", "ffmpeg.exe",
+            )
+        ),
+    ]
+    for path in candidates:
+        if os.path.isfile(path):
+            return os.path.dirname(path)
+    return None
+
+
+def ffmpeg_exe():
+    """Return the full path to the ffmpeg executable, or raise RuntimeError."""
+    ffmpeg_dir = find_ffmpeg()
+    if not ffmpeg_dir:
+        raise RuntimeError(
+            "ffmpeg not found. Install it (e.g. `winget install Gyan.FFmpeg`)."
+        )
+    return os.path.join(
+        ffmpeg_dir, "ffmpeg.exe" if os.name == "nt" else "ffmpeg"
+    )
+
+
+def start_first_minute_stream(link, duration=60, host="127.0.0.1", port=8090):
+    """
+    Serve the first `duration` seconds of a YouTube (or other site) video as an
+    HTTP network stream, and return (ffmpeg_process, url).
+
+    VLC's "Open Network Stream" box only accepts a network MRL (http://, rtsp://,
+    ...), not a local file path, so a downloaded clip won't play there. Instead we
+    turn the video into an actual network stream:
+
+      1. yt-dlp resolves the page URL to a direct media URL (see resolve_stream_url).
+      2. ffmpeg runs as a one-shot HTTP server (-listen 1) that reads that URL,
+         trims to the first `duration` seconds (-t) and remuxes to MPEG-TS on the
+         fly (-c copy, no re-encode). It blocks until a client connects, then
+         streams the trimmed clip.
+
+    VLC then opens http://host:port from the Network Stream dialog and plays it.
+
+    The caller owns the returned process and must terminate it when playback is
+    done (see play_livestream_youtube_video's finally block). Raises RuntimeError
+    if ffmpeg cannot be located.
+    """
+    ffmpeg = ffmpeg_exe()
+
+    # Resolve to a direct network URL; ffmpeg cannot read a YouTube page link.
+    direct_url = resolve_stream_url(link)
+
+    url = f"http://{host}:{port}"
+    print(f"Starting ffmpeg HTTP stream (first {duration}s) at {url} ...")
+    proc = subprocess.Popen(
+        [
+            ffmpeg,
+            "-hide_banner",
+            "-loglevel", "warning",
+            "-i", direct_url,
+            "-t", str(duration),      # stop after the first `duration` seconds
+            "-c", "copy",             # remux only, no re-encode (fast, cheap)
+            "-f", "mpegts",           # container VLC streams happily over HTTP
+            "-listen", "1",           # act as an HTTP server for one client
+            url,
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return proc, url
+
+
+def resolve_stream_url(link):
+    """
+    Resolve a YouTube (or other site) page URL to a direct, playable stream URL
+    using yt-dlp.
+
+    VLC 3.0.x cannot play YouTube page links itself: its bundled youtube.lua
+    extractor can no longer decipher YouTube's JavaScript-based stream signatures,
+    so VLC just shows a blank screen ("Couldn't extract video URL"). yt-dlp handles
+    that signature logic and hands us a direct googlevideo URL that VLC plays fine.
+
+    If resolution fails (e.g. the link is already a direct/network stream that VLC
+    handles natively), the original link is returned unchanged.
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "yt_dlp", "--no-playlist", "-f", "best[ext=mp4]/best", "-g", link],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        direct_url = result.stdout.strip().splitlines()
+        if result.returncode == 0 and direct_url:
+            print("Resolved direct stream URL via yt-dlp.")
+            return direct_url[0]
+        print(
+            "Warning: yt-dlp could not resolve the link; using it as-is. "
+            f"({result.stderr.strip().splitlines()[-1] if result.stderr.strip() else 'no details'})"
+        )
+    except FileNotFoundError:
+        print("Warning: yt-dlp not installed (pip install yt-dlp); using link as-is.")
+    except subprocess.TimeoutExpired:
+        print("Warning: yt-dlp timed out; using link as-is.")
+    return link
 
 
 async def play_livestream_youtube_video(youtube_link):
@@ -28,6 +159,12 @@ async def play_livestream_youtube_video(youtube_link):
     3. Paste a YouTube live link into the ComboBox
     4. Click Play to start streaming
     """
+    # Serve the first minute as an HTTP network stream. VLC's Network Stream box
+    # needs a network MRL (not a file path), so ffmpeg re-streams the trimmed clip
+    # over http:// (see start_first_minute_stream). If ffmpeg/yt-dlp fail this
+    # raises RuntimeError, which propagates out and aborts the app.
+    ffmpeg_proc, stream_url = start_first_minute_stream(youtube_link)
+
     desktop = terminator.Desktop(log_level="error")
     try:
         print("Opening VLC media player...")
@@ -36,8 +173,23 @@ async def play_livestream_youtube_video(youtube_link):
         )
         await asyncio.sleep(2)
 
-        print("Opening 'Open Network Stream' dialog...")
+        # Bring VLC to the foreground first. UIElement.press_key only reaches a
+        # window while it is focused, so if a stray VLC instance or a leftover
+        # error dialog holds focus, Ctrl+N silently goes nowhere. Activating the
+        # window makes the shortcut reliable.
+        try:
+            vlc_window.activate_window()
+        except Exception:
+            pass
+        await asyncio.sleep(0.5)
+
+        print("Opening 'Open Network Stream' dialog (Ctrl+N)...")
         vlc_window.press_key("{Ctrl}n")
+        # Alternative (equivalent) via the menu, if you prefer:
+        #   media_menu = await vlc_window.locator("Name:Media").first()
+        #   media_menu.click()
+        #   item = await desktop.locator("Name:Open Network Stream").first()
+        #   item.click()
         await asyncio.sleep(1.5)
 
         open_media_win = desktop.locator("window:Open Media")
@@ -45,7 +197,7 @@ async def play_livestream_youtube_video(youtube_link):
         combo = await open_media_win.locator("Name:Network Protocol Down").first()
         combo.click()
         await asyncio.sleep(0.5)
-        print(f"Pasting YouTube link: {youtube_link}")
+        print(f"Pasting stream link: {stream_url}")
         edit_box = (
             await open_media_win.locator("Name:Network Protocol Down")
             .locator("role:Edit")
@@ -54,7 +206,7 @@ async def play_livestream_youtube_video(youtube_link):
         edit_box.click()
         edit_box.press_key("{Ctrl}a")
         edit_box.press_key("{Delete}")
-        edit_box.type_text(youtube_link)
+        edit_box.type_text(stream_url)
         await asyncio.sleep(0.5)
 
         print("Clicking Play button...")
@@ -67,6 +219,16 @@ async def play_livestream_youtube_video(youtube_link):
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
         print(f"Error details: {str(e)}")
+    finally:
+        # Tear down the ffmpeg HTTP server. With -listen 1 it usually exits once
+        # VLC finishes reading the stream, but terminate it explicitly so we never
+        # leave the port bound if playback was cut short.
+        if ffmpeg_proc.poll() is None:
+            ffmpeg_proc.terminate()
+            try:
+                ffmpeg_proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                ffmpeg_proc.kill()
 
 
 async def play_local_video(video_filename="my_video.mp4"):

--- a/examples/win_calculator.py
+++ b/examples/win_calculator.py
@@ -11,11 +11,12 @@ async def run_calculator():
         # 1. Open Calculator
         print("Opening Calculator...")
         # Use calc.exe for better compatibility (UWP identifier may not work on all systems)
-        try:
-            calculator_window = desktop.open_application("uwp:Microsoft.WindowsCalculator")
-        except Exception:
-            # Fallback to calc.exe if UWP identifier fails
-            calculator_window = desktop.open_application("calc.exe")
+        # try:
+        calculator_window = desktop.open_application("Microsoft.WindowsCalculator_8wekyb3d8bbwe!App")
+        #     raise Exception("UWP identifier may not work on all systems, using calc.exe instead.")
+        # except Exception:
+        #     # Fallback to calc.exe if UWP identifier fails
+        # calculator_window = desktop.open_application("calc.exe")
         await asyncio.sleep(2)  # Allow app to open
 
         # Locators relative to the calculator window
@@ -23,10 +24,14 @@ async def run_calculator():
         display_element = calculator_window.locator(
             "nativeid:CalculatorResults"
         )  # Using AutomationId is often more stable
-        button_1 = await calculator_window.locator("Name:One").first()
-        button_plus = await calculator_window.locator("Name:Plus").first()
-        button_2 = await calculator_window.locator("Name:Two").first()
-        button_equals = await calculator_window.locator("Name:Equals").first()
+        # Use AutomationId (nativeid) rather than Name: the "Name:" selector does a
+        # case-insensitive *substring* match, so "Name:One" also matches the Scientific-mode
+        # buttons "'X' to the exponent" / "Ten to the exponent" / "Exponential" (they all
+        # contain "exp-ONE-nt"), and .first() would click the exponent button instead of "1".
+        button_1 = await calculator_window.locator("nativeid:num1Button").first()
+        button_plus = await calculator_window.locator("nativeid:plusButton").first()
+        button_2 = await calculator_window.locator("nativeid:num2Button").first()
+        button_equals = await calculator_window.locator("nativeid:equalButton").first()
 
         # 3. Get initial display text
         print("Getting initial display text...")


### PR DESCRIPTION

### Description
This PR compares the examples in this repo's `examples/` directory against the
upstream `terminator/examples` and captures the divergence. The changes make the
Windows examples run reliably on real machines, turn two thin demos into
end-to-end automations, add convenience runners for the whole suite, and rewrite
`examples/README.md` so it documents how to run each example and what it does.

Generated build artifacts excluded by `.gitignore` (`*.png`, `examples/screenshots/`)
were not part of this comparison.

### Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

### Video Demo (Recommended)
🎥 **Please include a video demo** showing your changes in action! We might use it to post on social media and grow the community.

**Suggested editing tools:**
- [Cap.so](https://cap.so/)
- [Screen.studio](https://screen.studio/)
- [CapCut](https://www.capcut.com/)
- [Kapwing](https://www.kapwing.com/)
- [Descript](https://www.descript.com/)


### AI Review & Code Quality
- [ ] I asked AI to critique my PR and incorporated feedback
- [ ] I formatted my code properly
- [x ] I tested my changes locally

### Checklist
- [ x] Code follows project style guidelines
- [ ] Added video demo (recommended)
- [ x] Updated documentation if needed

### Additional Notes
## Changed example scripts

### `win_calculator.py` — more robust selectors
- Switched button lookups from `Name:` to `nativeid:` (AutomationId) selectors
  (`num1Button`, `plusButton`, `num2Button`, `equalButton`). `Name:` does a
  case-insensitive **substring** match, so `Name:One` also matched the
  Scientific-mode exponent buttons (they contain "exp**one**nt"), and `.first()`
  could click the wrong button.
- Opens Calculator by its AppUserModelID
  (`Microsoft.WindowsCalculator_8wekyb3d8bbwe!App`) for a deterministic launch.

### `snipping_tool.py` — Windows 11 fixes
- Updated the snip-mode dropdown selector from `ComboBox:Snipping Mode` to
  `ComboBox:Snipping Area Dropdown Menu` to match current Windows 11 labeling.
- Added a short wait after clicking **New screenshot** so the full-screen capture
  overlay is active before the mouse press; otherwise the initial
  `mouse_click_and_hold` was lost and the circular drag ran without the button held.

### `element_screenshot.py` — meaningful capture + OCR (rewrite)
Previously it captured the first anonymous `role:Button` on the desktop and OCR'd
whatever that happened to be. Now it:
- Launches Notepad (by full path, to avoid third-party "notepad" shims), types
  multi-line sample text, and captures the **editor body** — a large, high-contrast
  target that OCR reads back reliably.
- Handles both Windows 11 (`role:Document`) and classic (`role:Edit`) Notepad.
- Highlights the element on screen and draws a border around the saved image so
  it's obvious which element was captured, and opens the result in the default
  image viewer (cross-platform).

### `vlc_auto_player.py` — real YouTube streaming (major rewrite)
- Adds `argparse` with `--file` (local video) and `--youtube-link` (network stream).
- YouTube support: resolves the page URL to a direct stream with **yt-dlp**, then
  runs **ffmpeg** as a one-shot HTTP server that trims and re-streams the first
  minute over `http://` (VLC's Network Stream box needs a network MRL, and VLC's
  bundled YouTube extractor can no longer decipher stream signatures on its own).
- Locates ffmpeg via `PATH` and, failing that, standard winget install locations,
  so a stale terminal `PATH` doesn't break the run.

### `gmail_automation.py` — end-to-end Gmail flow (major rewrite)
- Launches Chrome with a **dedicated automation profile** (`--user-data-dir`) so it
  runs alongside your everyday browser, and with `--force-renderer-accessibility`,
  which is required for Chrome to expose page content to the OS accessibility tree.
- Composes and sends an email, then reopens it from the Sent folder.
- Saves a numbered screenshot at each step (`screenshots/NN_*.png`) and a
  `99_FAILURE.png` full-screen capture on error, all best-effort (a screenshot
  failure never aborts the run).
- Uses precise, non-ambiguous window selectors (e.g. `name:contains:Gmail - Google Chrome`)
  and a generous login timeout for first-run sign-in.

## New files

- **`run_all.sh` / `run_all.ps1`** — run every example in the directory. Both skip
  the other-OS demos (`gnome-*`, `macos-*`) and `_*`-prefixed scratch scripts, run
  `vlc_auto_player.py` last, and prefer a `.venv/` interpreter if present. The
  PowerShell runner passes a default `--youtube-link` to the VLC example.
- **`_diag_vlc.py`** — a scratch diagnostic that probes whether VLC's `Ctrl+N`
  (Open Media) dialog appears with and without activating the window first. Kept
  as a debugging aid and excluded from the `run_all` runners by its `_` prefix.

## Documentation

- Rewrote **`examples/README.md`**: added Prerequisites, "Running the examples"
  (single script + `run_all` runners), a per-example "What each example does"
  table grouped by category, an accurate platform-compatibility matrix, and
  expanded troubleshooting (Chrome accessibility flag, VLC/yt-dlp). The old README
  referenced project directories that don't exist in this repo
  (`pdf-to-form/`, `ai-explorer/`, `nextjs-workflows/`); the table now reflects
  what is actually present.

## Not included from upstream

The upstream `examples/` also contains three standalone sub-projects that were
**not** brought into this repo and are out of scope here:
`mcp-client-elicitation/`, `recaptcha-resolver/`, and `strip-ui-styles/`.

## Testing

Run the Windows suite from the repo root:

```bash
./examples/run_all.ps1     # Windows / PowerShell
./examples/run_all.sh      # Git Bash
```

Or a single example, e.g. `python examples/win_calculator.py`. The scripts drive
real UI, so run them on a machine where you can watch the windows and don't need
the mouse/keyboard while they execute.

---

### Housekeeping note
`examples/_out.txt` is an empty stray output file with no consumer; it can be
removed (or added to `.gitignore`).


